### PR TITLE
Update do build system to support some build modes

### DIFF
--- a/do
+++ b/do
@@ -1,25 +1,84 @@
-#!/bin/sh
-die() { echo $1; exit 1; }
+#!/usr/bin/env bash
+LANG=C LC_ALL=C
+die() { printf '%s\n' "${1}" 1>&2; exit 1; };
+usage() {
+if [ "${#}" -lt 1 ]; then
+	printf '\n%s\n\n' "Usage: ./do [ARGS]"
+	printf '%s\n' "Build Options:"
+	printf '%s\n' " -v	Enable verbose compiler output"
+	printf '%s\n' " -x	Enable debugging compiler output"
+	printf '%s\n\n' " -f	Fully rebuild all source packages"
+	printf '%s\n' "Build Modes:"
+	printf '%s\n' " -d	Go defaults (default mode if build mode not specified) **"
+	printf '%s\n' " -p	pure, attempt static-linked Pure Go-only build (includes symbols)"
+	printf '%s\n' " -r	hard, Full RELRO/PIE/FORTIFY/ASLR/SSP/NX build (no symbols)"
+	printf '\n%s\n\n' " **	Defaults often between distribution-provided Golang packages!"
+	exit 1
+fi
+}
+
+GCFLAGS="-trimpath"
+
+while getopts ":xrvfpdha" option
+do
+  case "$option"
+  in
+  r) export ARGS="-buildmode=pie $ARGS"; export CGO_ENABLED=1; export CGO_CPPFLAGS="${CGO_CPPFLAGS:-} -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-all -fstack-clash-protection"; export CGO_CFLAGS="${CGO_CFLAGS:-} -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-all -fstack-clash-protection"; export CGO_CPPFLAGS="${CGO_CPPFLAGS:-} -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-all -fstack-clash-protection"; export CGO_CXXFLAGS="${CGO_CXXFLAGS:-} -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-all -fstack-clash-protection"; export CGO_FFLAGS="${CGO_FFLAGS:-} -O2 -D_FORTIFY_SOURCE=2"; export CGO_LDFLAGS="${CGO_LDFLAGS:-} -O2 -D_FORTIFY_SOURCE=2"; export CGO_LDFLAGS="${CGO_LDFLAGS:-} -s -w -Wl,-z,relro,-z,now"; export LD_FLAGS=" -s -w -extldflags=-Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now,--build-id=none "; export BUILDMODE="${BUILDMODE}R"; export LINKMODE="-linkmode=external -buildid= ";;
+  v) ARGS="$ARGS -v";;
+  x) ARGS="$ARGS -x";;
+  f) ARGS="$ARGS -a";;
+  p) ARGS="$ARGS " CGO_ENABLED=0 GODEBUG=netdns=go BUILD_TAGS="-tags=netgo,osusergo" BUILDMODE="${BUILDMODE}P";;
+  d) ARGS="$ARGS " BUILDMODE="${BUILDMODE}D";;
+  h) usage;;
+ \?) { printf '%s\n' "./do: Invalid option -$OPTARG; see \"./do -h\" for usage." 1>&2 ; exit 1; }; ;;
+  :) usage;;
+  *) usage;;
+  esac
+done
+
+if [ -z "${ARGS}" ]; then
+	usage
+fi
+
+MODESPEC=${#BUILDMODE}
+if [ "${MODESPEC}" -gt 1 ]; then
+	die "./do: Error: Use only one Build Mode; see \"./do -h\" for usage."
+fi
+
 export GO111MODULE=on
 PKTD_GIT_ID=$(git describe --tags HEAD)
 if ! git diff --quiet; then
-    if test "x$PKT_FAIL_DIRTY" != x; then
-        echo "Build is dirty, failing"
-        git diff
-        exit 1;
+    if test "x${PKT_FAIL_DIRTY}" != x; then
+        printf '%s\n' "Build is dirty, aborting."
+  #      git diff
+  #      exit 1;
     fi
     PKTD_GIT_ID="${PKTD_GIT_ID}-dirty"
 fi
-PKTD_LDFLAGS="-X github.com/pkt-cash/pktd/pktconfig/version.appBuild=${PKTD_GIT_ID}"
+PKTD_LDFLAGS="${LINKMODE}-X github.com/pkt-cash/pktd/pktconfig/version.appBuild=${PKTD_GIT_ID}${LD_FLAGS}"
 
-mkdir -p ./bin
-echo "Building pktd"
-go build -ldflags="${PKTD_LDFLAGS}" -o ./bin/pktd || die "failed to build pktd"
-echo "Building wallet"
-go build -ldflags="${PKTD_LDFLAGS}" -o ./bin/pktwallet ./pktwallet || die "failed to build wallet"
-echo "Building btcctl"
-go build -ldflags="${PKTD_LDFLAGS}" -o ./bin/pktctl ./cmd/btcctl || die "failed to build pktctl"
-echo "Running tests"
-go test ./... || die "tests failed"
-./bin/pktd --version || die "can't run pktd"
-echo "Everything looks good - use ./bin/pktd to launch"
+if [ ! -d "./bin" ]; then
+	mkdir -p ./bin ||\
+		die "mkdir failed; exiting."
+fi
+
+printf '%s\n' "Building pktd"
+go build ${ARGS} ${BUILD_TAGS} -ldflags "${PKTD_LDFLAGS}" ${GCFLAGS} -o ./bin/pktd . ||\
+	die "Failed to build pktd"
+
+printf '%s\n' "Building pktwallet"
+go build ${ARGS} ${BUILD_TAGS} -ldflags "${PKTD_LDFLAGS}" ${GCFLAGS} -o ./bin/pktwallet ./pktwallet ||\
+	die "Failed to build pktwallet"
+
+printf '%s\n' "Building pktctl"
+go build ${ARGS} ${BUILD_TAGS} -ldflags "${PKTD_LDFLAGS}" ${GCFLAGS} -o ./bin/pktctl ./cmd/btcctl ||\
+	die "Failed to build pktctl"
+
+printf '%s\n' "Running tests"
+go test ./... ||\
+	die "Tests failed"
+
+./bin/pktd --version ||\
+	die "Error: Couldn't run compiled pktd"
+
+printf '%s\n' "Build completed; output in ./bin"


### PR DESCRIPTION

---> I know you probably can't adopt this because 
of the bashisms as OSX is dropping GNU tools, but
this was an attempt to change do for the following
WITHOUT the whole subPOSIX framework I wrote. This
is likely going to have to be rewritten in Go. Or
something similar, but it'll never be as good or as
hardend as newDo

﻿ * While it does not enable the full environment
   sanitization, testing, and normalization features
   of newDo - it provides two of the most important
   build modes:

    a) A "Pure Go" static build, which (at least on
       Linux/x86_64) will not require any system C
       runtime or other libraries and produces a fully
       static binary that should have extremely wide
       compatability across all Linux systems of this
       type, without any hidden dependencies introduced
       by glibc's lack of support for static linking or
       dynamically loaded resolvers and other componenets.

    b) A "hardened" PIE-mode build, but is dependent on a
       modern Linux kernel (3.2.0+ ABI) and dynamic linker
       for relocation. This configuration was developed by
       Red Hat and IBM, and is the default when using the
       latest versions of their distributed Go Toolset. It
       provides Full RELRO, SSP/Stack Canary, PIE/ASLR, no
       RPATH, RUNPATH, or DWARF/debug symbols, and uses a
       non-executable (NX) stack.  Compiling with this mode
       enabled requires a sufficiently up to date system
       linker and toolchain (such as that which is provided
       with Fedora 23 or higher.)
