### PR TITLE
Add deepsource.toml for the DeepSource bot 

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_paths = ["github.com/pkt-cash/pktd"]


### PR DESCRIPTION
to to be confused with deep space 9
or the deep south - a freebie for now﻿
