### PR TITLE
Properly use only American English Standard words

### DIFF
--- a/blockchain/indexers/common.go
+++ b/blockchain/indexers/common.go
@@ -24,7 +24,7 @@ var (
 	// fields for storage in the database.
 	byteOrder = binary.LittleEndian
 
-	// errInterruptRequested indicates that an operation was cancelled due
+	// errInterruptRequested indicates that an operation was canceled due
 	// to a user-requested interrupt.
 	errInterruptRequested = Err.Code("errInterruptRequested")
 

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -27,7 +27,7 @@ const (
 	blockHdrOffset = 12
 )
 
-// errInterruptRequested indicates that an operation was cancelled due
+// errInterruptRequested indicates that an operation was canceled due
 // to a user-requested interrupt.
 var errInterruptRequested = errors.New("interrupt requested")
 
@@ -521,7 +521,7 @@ func upgradeUtxoSetToV2(db database.DB, interrupt <-chan struct{}) er.R {
 
 			if interruptRequested(interrupt) {
 				// No error here so the database transaction
-				// is not cancelled and therefore outstanding
+				// is not canceled and therefore outstanding
 				// work is written to disk.
 				break
 			}

--- a/btcec/signature.go
+++ b/btcec/signature.go
@@ -284,7 +284,7 @@ func hashToInt(hash []byte, c elliptic.Curve) *big.Int {
 // in the inner loop in Step 1. The counter provided is actually the j parameter
 // of the loop * 2 - on the first iteration of j we do the R case, else the -R
 // case in step 1.6. This counter is used in the bitcoin compressed signature
-// format and thus we match bitcoind's behaviour here.
+// format and thus we match bitcoind's behavior here.
 func recoverKeyFromSignature(curve *KoblitzCurve, sig *Signature, msg []byte,
 	iter int, doChecks bool) (*PublicKey, er.R) {
 	// 1.1 x = (n * i) + r

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -100,7 +100,7 @@ type GetAddedNodeInfoResult struct {
 }
 
 // SoftForkDescription describes the current state of a soft-fork which was
-// deployed using a super-majority block signalling.
+// deployed using a super-majority block signaling.
 type SoftForkDescription struct {
 	ID      string `json:"id"`
 	Version uint32 `json:"version"`

--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -417,7 +417,7 @@ func (cm *ConnManager) Connect(c *ConnReq) {
 	}
 
 	// During the time we wait for retry there is a chance that
-	// this connection was already cancelled
+	// this connection was already canceled
 	if c.State() == ConnCanceled {
 		log.Debugf("Ignoring connect for canceled connreq=%v", c)
 		return

--- a/database/ffldb/interface_test.go
+++ b/database/ffldb/interface_test.go
@@ -2174,7 +2174,7 @@ func testConcurrecy(tc *testContext) bool {
 func testConcurrentClose(tc *testContext) bool {
 	// Start up a few readers and wait for them to acquire views.  Each
 	// reader waits for a signal to complete to ensure the transactions stay
-	// open until they are explicitly signalled to be closed.
+	// open until they are explicitly signaled to be closed.
 	var activeReaders int32
 	numReaders := 3
 	started := make(chan struct{})

--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -149,9 +149,9 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	// *** ThresholdDefined part 2 - 1 block prior to ThresholdStarted ***
 	//
 	// Generate enough blocks to reach the height just before the first
-	// state transition without signalling support since the state should
+	// state transition without signaling support since the state should
 	// move to started once the start time has been reached regardless of
-	// support signalling.
+	// support signaling.
 	//
 	// NOTE: This is two blocks before the confirmation window because the
 	// getblockchaininfo RPC reports the status for the block AFTER the
@@ -289,7 +289,7 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 //   ThresholdLockedIn
 //   - Assert chain height is expected and state is still ThresholdStarted
 // - Generate enough blocks to reach the next state transition window with only
-//   the exact number of blocks required to achieve locked in status signalling
+//   the exact number of blocks required to achieve locked in status signaling
 //   support.
 //   - Assert chain height is expected and state moved to ThresholdLockedIn
 // - Generate 1 fewer blocks than needed to reach the next state transition

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -331,7 +331,7 @@ func (h *Harness) connectRPCClient() er.R {
 // include a change output indicated by the change boolean. Any unspent outputs
 // selected as inputs for the crafted transaction are marked as unspendable in
 // order to avoid potential double-spends by future calls to this method. If the
-// created transaction is cancelled for any reason then the selected inputs MUST
+// created transaction is canceled for any reason then the selected inputs MUST
 // be freed via a call to UnlockOutputs. Otherwise, the locked inputs won't be
 // returned to the pool of spendable outputs.
 //

--- a/mining/cpuminer/cpuminer.go
+++ b/mining/cpuminer/cpuminer.go
@@ -451,7 +451,7 @@ func (m *CPUMiner) Start() {
 	log.Infof("CPU miner started")
 }
 
-// Stop gracefully stops the mining process by signalling all workers, and the
+// Stop gracefully stops the mining process by signaling all workers, and the
 // speed monitor to quit.  Calling this function when the CPU miner has not
 // already been started will have no effect.
 //

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -395,7 +395,7 @@ func (sm *SyncManager) isSyncCandidate(peer *peerpkg.Peer) bool {
 	return true
 }
 
-// handleNewPeerMsg deals with new peers that have signalled they may
+// handleNewPeerMsg deals with new peers that have signaled they may
 // be considered as a sync peer (they have already successfully negotiated).  It
 // also starts syncing if needed.  It is invoked from the syncHandler goroutine.
 func (sm *SyncManager) handleNewPeerMsg(peer *peerpkg.Peer) {
@@ -473,7 +473,7 @@ func (sm *SyncManager) shouldDCStalledSyncPeer() bool {
 	return peerHeight > best.Height
 }
 
-// handleDonePeerMsg deals with peers that have signalled they are done.  It
+// handleDonePeerMsg deals with peers that have signaled they are done.  It
 // removes the peer as a candidate for syncing and in the case where it was
 // the current sync peer, attempts to select a new best peer to sync from.  It
 // is invoked from the syncHandler goroutine.

--- a/neutrino/blockmanager.go
+++ b/neutrino/blockmanager.go
@@ -343,7 +343,7 @@ func (b *blockManager) NewPeer(sp *ServerPeer) {
 	}
 }
 
-// handleNewPeerMsg deals with new peers that have signalled they may be
+// handleNewPeerMsg deals with new peers that have signaled they may be
 // considered as a sync peer (they have already successfully negotiated).  It
 // also starts syncing if needed.  It is invoked from the syncHandler
 // goroutine.
@@ -401,7 +401,7 @@ func (b *blockManager) DonePeer(sp *ServerPeer) {
 	}
 }
 
-// handleDonePeerMsg deals with peers that have signalled they are done.  It
+// handleDonePeerMsg deals with peers that have signaled they are done.  It
 // removes the peer as a candidate for syncing and in the case where it was the
 // current sync peer, attempts to select a new best peer to sync from.  It is
 // invoked from the syncHandler goroutine.

--- a/neutrino/blockntfns/manager_test.go
+++ b/neutrino/blockntfns/manager_test.go
@@ -132,7 +132,7 @@ func TestManagerCancelSubscription(t *testing.T) {
 	defer subMgr.Stop()
 
 	// We'll create two client subscriptions to ensure subscription
-	// cancellation works as intended. We'll be canceling the second
+	// cancelation works as intended. We'll be canceling the second
 	// subscription only.
 	sub1, err := subMgr.NewSubscription(0)
 	if err != nil {

--- a/neutrino/errors.go
+++ b/neutrino/errors.go
@@ -7,9 +7,9 @@ import (
 var Err er.ErrorType = er.NewErrorType("neutrino.Err")
 
 var (
-	// ErrGetUtxoCancelled signals that a GetUtxo request was cancelled.
-	ErrGetUtxoCancelled = Err.CodeWithDetail("ErrGetUtxoCancelled",
-		"get utxo request cancelled")
+	// ErrGetUtxoCanceled signals that a GetUtxo request was canceled.
+	ErrGetUtxoCanceled = Err.CodeWithDetail("ErrGetUtxoCanceled",
+		"getutxorequest cancellation")
 
 	// ErrShuttingDown signals that neutrino received a shutdown request.
 	ErrShuttingDown = Err.CodeWithDetail("ErrShuttingDown",

--- a/neutrino/neutrino.go
+++ b/neutrino/neutrino.go
@@ -1029,7 +1029,7 @@ func (s *ChainService) peerHandler() {
 				// here. This is rather strange since the
 				// values looked up by the DNS seed lookups
 				// will vary quite a lot.  to replicate this
-				// behaviour we put all addresses as having
+				// behavior we put all addresses as having
 				// come from the first one.
 				s.addrManager.AddAddresses(
 					validAddrs, validAddrs[0],
@@ -1197,7 +1197,7 @@ func (s *ChainService) handleAddPeerMsg(state *peerState, sp *ServerPeer) bool {
 	return true
 }
 
-// handleDonePeerMsg deals with peers that have signalled they are done.  It is
+// handleDonePeerMsg deals with peers that have signaled they are done.  It is
 // invoked from the peerHandler goroutine.
 func (s *ChainService) handleDonePeerMsg(state *peerState, sp *ServerPeer) {
 	var list map[int32]*ServerPeer

--- a/neutrino/sync_test.go
+++ b/neutrino/sync_test.go
@@ -176,13 +176,13 @@ var (
 
 	// ourKnownTxsByBlock lets the rescan goroutine keep track of
 	// transactions we're interested in that are in the blockchain we're
-	// following as signalled by OnBlockConnected, OnBlockDisconnected,
+	// following as signaled by OnBlockConnected, OnBlockDisconnected,
 	// OnRecvTx, and OnRedeemingTx.
 	ourKnownTxsByBlock = make(map[chainhash.Hash][]*btcutil.Tx)
 
 	// ourKnownTxsByFilteredBlock lets the rescan goroutine keep track of
 	// transactions we're interested in that are in the blockchain we're
-	// following as signalled by OnFilteredBlockConnected and
+	// following as signaled by OnFilteredBlockConnected and
 	// OnFilteredBlockDisconnected.
 	ourKnownTxsByFilteredBlock = make(map[chainhash.Hash][]*btcutil.Tx)
 )

--- a/neutrino/utxoscanner.go
+++ b/neutrino/utxoscanner.go
@@ -72,7 +72,7 @@ func (r *GetUtxoRequest) Result(cancel <-chan struct{}) (*SpendReport, er.R) {
 		return r.result.report, r.result.err
 
 	case <-cancel:
-		return nil, ErrGetUtxoCancelled.Default()
+		return nil, ErrGetUtxoCanceled.Default()
 
 	case <-r.quit:
 		return nil, ErrShuttingDown.Default()

--- a/neutrino/utxoscanner_test.go
+++ b/neutrino/utxoscanner_test.go
@@ -495,36 +495,36 @@ func TestUtxoScannerCancelRequest(t *testing.T) {
 	// Check that neither succeed without any further action.
 	select {
 	case <-err100000:
-		t.Fatalf("getutxo should not have been cancelled yet")
+		t.Fatalf("getutxo should not have been canceled yet")
 	case <-time.After(50 * time.Millisecond):
 	}
 
 	select {
 	case <-err100001:
-		t.Fatalf("getutxo should not have been cancelled yet")
+		t.Fatalf("getutxo should not have been canceled yet")
 	case <-time.After(50 * time.Millisecond):
 	}
 
 	// Cancel the first request, which should cause it to return
-	// ErrGetUtxoCancelled.
+	// ErrGetUtxoCanceled.
 	close(cancel100000)
 
 	select {
 	case err := <-err100000:
-		if !ErrGetUtxoCancelled.Is(err) {
+		if !ErrGetUtxoCanceled.Is(err) {
 			t.Fatalf("unexpected error returned "+
 				"from Result, want: %v, got %v",
-				ErrGetUtxoCancelled, err)
+				ErrGetUtxoCanceled, err)
 		}
 	case <-time.After(50 * time.Millisecond):
-		t.Fatalf("getutxo should have been cancelled")
+		t.Fatalf("getutxo should have been canceled")
 	}
 
 	// The second task shouldn't have been started yet, and should deliver a
 	// message since it wasn't tied to the same cancel chan.
 	select {
 	case <-err100001:
-		t.Fatalf("getutxo should not have been cancelled yet")
+		t.Fatalf("getutxo should not have been canceled yet")
 	case <-time.After(50 * time.Millisecond):
 	}
 
@@ -537,7 +537,7 @@ func TestUtxoScannerCancelRequest(t *testing.T) {
 		scanner.Stop()
 	}()
 
-	// The second request should be cancelled as soon as the utxoscanner
+	// The second request should be canceled as soon as the utxoscanner
 	// begins shut down, returning ErrShuttingDown.
 	select {
 	case err := <-err100001:
@@ -547,7 +547,7 @@ func TestUtxoScannerCancelRequest(t *testing.T) {
 				ErrShuttingDown, err)
 		}
 	case <-time.After(50 * time.Millisecond):
-		t.Fatalf("getutxo should have been cancelled")
+		t.Fatalf("getutxo should have been canceled")
 	}
 
 	// Ensure that GetBlock gets unblocked so the batchManager can properly

--- a/peer/README.md
+++ b/peer/README.md
@@ -34,7 +34,7 @@ A quick overview of the major features peer provides are as follows:
      they see fit (proxies, etc)
    - User agent name and version
    - Bitcoin network
-   - Service support signalling (full nodes, bloom filters, etc)
+   - Service support signaling (full nodes, bloom filters, etc)
    - Maximum supported protocol version
    - Ability to register callbacks for handling bitcoin protocol messages
  - Inventory message batching and send trickling with known inventory detection

--- a/peer/doc.go
+++ b/peer/doc.go
@@ -29,7 +29,7 @@ A quick overview of the major features peer provides are as follows:
      they see fit (proxies, etc)
    - User agent name and version
    - Bitcoin network
-   - Service support signalling (full nodes, bloom filters, etc)
+   - Service support signaling (full nodes, bloom filters, etc)
    - Maximum supported protocol version
    - Ability to register callbacks for handling bitcoin protocol messages
  - Inventory message batching and send trickling with known inventory detection

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -65,7 +65,7 @@ func Example_newOutboundPeer() {
 	// Create an outbound peer that is configured to act as a simnet node
 	// that offers no services and has listeners for the version and verack
 	// messages.  The verack listener is used here to signal the code below
-	// when the handshake has been finished by signalling a channel.
+	// when the handshake has been finished by signaling a channel.
 	verack := make(chan struct{})
 	peerCfg := &peer.Config{
 		UserAgentName:    "peer",  // User agent name to advertise.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -860,7 +860,7 @@ func (p *Peer) WantsHeaders() bool {
 	return sendHeadersPreferred
 }
 
-// IsWitnessEnabled returns true if the peer has signalled that it supports
+// IsWitnessEnabled returns true if the peer has signaled that it supports
 // segregated witness.
 //
 // This function is safe for concurrent access.
@@ -1297,7 +1297,7 @@ out:
 				}
 
 			case sccHandlerStart:
-				// Warn on unbalanced callback signalling.
+				// Warn on unbalanced callback signaling.
 				if handlerActive {
 					log.Warn("Received handler start " +
 						"control command while a " +
@@ -1309,7 +1309,7 @@ out:
 				handlersStartTime = time.Now()
 
 			case sccHandlerDone:
-				// Warn on unbalanced callback signalling.
+				// Warn on unbalanced callback signlling.
 				if !handlerActive {
 					log.Warn("Received handler done " +
 						"control command when a " +

--- a/pktwallet/rpc/legacyrpc/methods.go
+++ b/pktwallet/rpc/legacyrpc/methods.go
@@ -1703,7 +1703,7 @@ func validateAddress(icmd interface{}, w *wallet.Wallet) (interface{}, er.R) {
 	// We could put whether or not the address is a script here,
 	// by checking the type of "addr", however, the reference
 	// implementation only puts that information if the script is
-	// "ismine", and we follow that behaviour.
+	// "ismine", and we follow that behavior.
 	result.Address = addr.EncodeAddress()
 	result.IsValid = true
 

--- a/pktwallet/waddrmgr/manager.go
+++ b/pktwallet/waddrmgr/manager.go
@@ -186,7 +186,7 @@ func newSecretKey(passphrase *[]byte, config *ScryptOptions) (*snacl.SecretKey, 
 }
 
 // EncryptorDecryptor provides an abstraction on top of snacl.CryptoKey so that
-// our tests can use dependency injection to force the behaviour they need.
+// our tests can use dependency injection to force the behavior they need.
 type EncryptorDecryptor interface {
 	Encrypt(in []byte) ([]byte, er.R)
 	Decrypt(in []byte) ([]byte, er.R)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1329,7 +1329,7 @@ func handleGetBlockChainInfo(s *rpcServer, cmd interface{}, closeChan <-chan str
 
 	// Next, populate the response with information describing the current
 	// status of soft-forks deployed via the super-majority block
-	// signalling mechanism.
+	// signaling mechanism.
 	height := chainSnapshot.Height
 	chainInfo.SoftForks = []*btcjson.SoftForkDescription{
 		{

--- a/server.go
+++ b/server.go
@@ -1648,7 +1648,7 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 	return true
 }
 
-// handleDonePeerMsg deals with peers that have signalled they are done.  It is
+// handleDonePeerMsg deals with peers that have signaled they are done.  It is
 // invoked from the peerHandler goroutine.
 func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 	var list map[int32]*serverPeer
@@ -2111,7 +2111,7 @@ func (s *server) peerHandler() {
 				// Bitcoind uses a lookup of the dns seeder here. This
 				// is rather strange since the values looked up by the
 				// DNS seed lookups will vary quite a lot.
-				// to replicate this behaviour we put all addresses as
+				// to replicate this behavior we put all addresses as
 				// having come from the first one.
 				s.addrManager.AddAddresses(addrs, addrs[0])
 			})

--- a/txscript/sign.go
+++ b/txscript/sign.go
@@ -220,7 +220,7 @@ func sign(chainParams *chaincfg.Params, tx *wire.MsgTx, idx int,
 // and nrequired are the result of extracting the addresses from pkscript.
 // The return value is the best effort merging of the two scripts. Calling this
 // function with addresses, class and nrequired that do not match pkScript is
-// an error and results in undefined behaviour.
+// an error and results in undefined behavior.
 func mergeScripts(chainParams *chaincfg.Params, tx *wire.MsgTx, idx int,
 	pkScript []byte, class ScriptClass, addresses []btcutil.Address,
 	nRequired int, sigScript, prevScript []byte) []byte {
@@ -273,7 +273,7 @@ func mergeScripts(chainParams *chaincfg.Params, tx *wire.MsgTx, idx int,
 	// has either zero signature, can't be spent, or has a single signature
 	// which is either present or not. The other two cases are handled
 	// above. In the conflict case here we just assume the longest is
-	// correct (this matches behaviour of the reference implementation).
+	// correct (this matches behavior of the reference implementation).
 	default:
 		if len(sigScript) > len(prevScript) {
 			return sigScript
@@ -287,7 +287,7 @@ func mergeScripts(chainParams *chaincfg.Params, tx *wire.MsgTx, idx int,
 // and nRequired should be the results from extracting the addresses from
 // pkScript. Since this function is internal only we assume that the arguments
 // have come from other functions internally and thus are all consistent with
-// each other, behaviour is undefined if this contract is broken.
+// each other, behavior is undefined if this contract is broken.
 func mergeMultiSig(tx *wire.MsgTx, idx int, addresses []btcutil.Address,
 	nRequired int, pkScript, sigScript, prevScript []byte) []byte {
 

--- a/wire/msgalert.go
+++ b/wire/msgalert.go
@@ -117,10 +117,10 @@ type Alert struct {
 	ID int32
 
 	// All alerts with an ID less than or equal to this number should
-	// cancelled, deleted and not accepted in the future
+	// canceled, deleted and not accepted in the future
 	Cancel int32
 
-	// All alert IDs contained in this set should be cancelled as above
+	// All alert IDs contained in this set should be canceled as above
 	SetCancel []int32
 
 	// This alert only applies to versions greater than or equal to this


### PR DESCRIPTION
signall vs. signal .. cancell vs. cancel ! My god man!

There are WAY more (British vs. American issues and use
is TOTALLY INCONSISTENT within the code base), but these
are, to me, the most egregious and wrong-looking ones.
The ones that are acceptable like "standardisation" use
the American "standardization" - none of it makes sense.

There are dozens if not hundreds of cases of mixed use,
often in the same file, sometimes in the same paragraph!

I've really only scratched the surface of it with this PR.

Just looking at these, though, is giving me eye cancer,
dissolving my soul, accelerating my descent into insanity.

I do think we should adopt American English as THE standard,
actually, for both documentation and code, American English
has always clearly been the standard language of the Internet.

Over at the supposedly "international" ISO, you can see the
"The International Organization for Standardization" and NOT
the "The British and Welsh Organisation for Standardisation".

Also, all the seed words we use are ONLY in American English.
We got "color" & "labor" & "humor" there. We got "truck" also,
but not a single "lorry" to be found.  If we are going to keep
using a mixed language base, would we have to change these too?

If we keep mixing, people will just think we are Canadians! ***
(*** Of course, being dead is preferred to being Canadian.)

[FYI: Merging this would increase my productivity by 20%.]
