### PR TITLE
Small improvements for: peer, syncmgr, do, pktwallet

### DIFF
--- a/do
+++ b/do
@@ -1,25 +1,117 @@
-#!/bin/sh
-die() { echo $1; exit 1; }
-export GO111MODULE=on
-PKTD_GIT_ID=$(git describe --tags HEAD)
-if ! git diff --quiet; then
-    if test "x$PKT_FAIL_DIRTY" != x; then
-        echo "Build is dirty, failing"
-        git diff
-        exit 1;
-    fi
-    PKTD_GIT_ID="${PKTD_GIT_ID}-dirty"
-fi
-PKTD_LDFLAGS="-X github.com/pkt-cash/pktd/pktconfig/version.appBuild=${PKTD_GIT_ID}"
+#!/usr/bin/env sh
+# shellcheck disable=SC2015
 
-mkdir -p ./bin
-echo "Building pktd"
-go build -ldflags="${PKTD_LDFLAGS}" -o ./bin/pktd || die "failed to build pktd"
-echo "Building wallet"
-go build -ldflags="${PKTD_LDFLAGS}" -o ./bin/pktwallet ./pktwallet || die "failed to build wallet"
-echo "Building btcctl"
-go build -ldflags="${PKTD_LDFLAGS}" -o ./bin/pktctl ./cmd/btcctl || die "failed to build pktctl"
-echo "Running tests"
-go test ./... || die "tests failed"
-./bin/pktd --version || die "can't run pktd"
-echo "Everything looks good - use ./bin/pktd to launch"
+just() {
+	"$@" || true :
+}
+
+say() {
+	printf '%s\n' "${*}" ||\
+		just printf '%s\n' ""
+}
+
+die() {
+	just say "Error ${?}: ${*}" >&2
+	exit 1;
+}
+
+try() {
+	"$@" ||\
+		{ die "${*}"; };
+}
+
+doBuild() {
+	if [ "${#}" -lt 2 ]; then
+		just say "doBuild(null): Malformed input."
+		return 1
+	else
+		target="${1:?}"
+		output="${2:?}"
+		just say "Building ${output:?}"
+		${doRun} go build "-o" "${output:?}" "-trimpath" "-ldflags=${PKTD_LDFLAGS:?} -buildid= -linkmode=auto -extldflags=-static" "-tags=osusergo,netgo,static_build" "${target:?}" ||\
+			{ die "doBuild(${target:?}): Go build failed."
+				return 1; };
+	fi
+}
+
+if command stdbuf -oL true 1>/dev/null 2>&1; then
+	doRun="stdbuf -oL command" &&\
+		export doRun ||\
+			{ die "Could not export doRun variable."; };
+else
+	doRun="command" &&\
+		export DoRun ||\
+			{ die "Could not export doRun variable."; };
+fi
+
+if say "X" |\
+	${doRun} grep -q --line-buffered "X" 1>/dev/null 2>&1; then
+	lineBuffered="--line-buffered" &&\
+		export lineBuffered ||\
+			{ die "Could not export lineBuffered variable."; };
+fi
+
+GO111MODULE="on" &&\
+	export GO111MODULE ||\
+		{ die "Could not export GO111MODULE variable."; }; 
+
+CGO_ENABLED=0 &&\
+	export CGO_ENABLED ||\
+		{ die "Could not export CGO_ENABLED variable."; };
+
+LC_ALL=C &&\
+	export LC_ALL ||\
+		{ die "Could not export LC_ALL variable."; };
+
+BINDIR="./bin" &&\
+	export BINDIR ||\
+		{ die "Could not export BINDIR variable."; };
+
+if ! ${doRun} git version 1>/dev/null 2>&1; then
+	die "Could not execute \"git version\" command."
+fi
+
+if ! ${doRun} go version 1>/dev/null 2>&1; then
+	die "Could not execute \"go version\" command."
+fi
+
+PKTD_GIT_ID=$(${doRun} git describe --tags HEAD --always) ||\
+	die "\"git describe\" failed. Unable to set PKTD_GIT_ID."
+export PKTD_GIT_ID ||\
+	die "Could not export PKTD_GIT_ID variable."
+
+if ! ${doRun} git diff --ignore-cr-at-eol --quiet 1>/dev/null 2>&1; then
+	PKTD_GIT_ID="${PKTD_GIT_ID:?}-dirty" &&\
+		export PKTD_GIT_ID ||\
+			{ die "Could not export PKTD_GIT_ID variable."; };
+	PKT_DIRTY_OUTPUT=$(${doRun} git diff --ignore-cr-at-eol -p 2>&1)
+	if [ "${PKT_FAIL_DIRTY:=1}" -ne 0 ]; then
+			if [ -n "${PKT_DIRTY_OUTPUT:-}" ]; then
+				just say "${PKT_DIRTY_OUTPUT:?}"
+				die "Build is dirty; changes shown above; aborting build."
+			else
+				die "Build is dirty; aborting build."
+			fi
+	fi
+fi
+
+PKTD_LDFLAGS="-X github.com/pkt-cash/pktd/pktconfig/version.appBuild=${PKTD_GIT_ID:?}" &&\
+	export PKTD_LDFLAGS ||\
+		{ die "Could not export PKTD_LDFLAGS variable."; };
+
+mkdir -p "${BINDIR:?}" ||\
+	die "Could not create output directory \"${BINDIR:?}\"; aborting build."
+
+try doBuild "." "${BINDIR}/pktd"
+try doBuild "./pktwallet" "${BINDIR}/pktwallet"
+try doBuild "./cmd/btcctl" "${BINDIR}/pktctl"
+
+test_timeout="15s"
+just say "Testing (${test_timeout} timeout)"
+${doRun} go test -timeout="${test_timeout}" -count=1 ./... |\
+	${doRun} grep "${lineBuffered:-}" -v '\[no test files\]' |\
+		${doRun} grep "${lineBuffered:-}" -F -e '' -e '' -e 'FAIL' &&\
+			{ false && die "One or more tests failed."; };
+${doRun} "${BINDIR}"/pktd --version ||\
+	die "Failed to execute compiled pktd binary." &&\
+		just say "Successful build!"

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7
 	github.com/json-iterator/go v1.1.10
 	github.com/kkdai/bstream v1.0.0
+	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lightningnetwork/lnd/queue v1.0.5-0.20201016111222-d12f76fd6d48
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
@@ -31,5 +32,6 @@ require (
 	golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a // indirect
 	google.golang.org/genproto v0.0.0-20201021134325-0d71844de594 // indirect
 	google.golang.org/grpc v1.34.0-dev.0.20201021230544-4e8458e5c638
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/LK4D4/trylock v0.0.0-20191027065348-ff7e133a5c54 h1:sg9CWNOhr58hMGmJ0q7x7jQ/B1RK/GyHNmeaYCJos9M=
-github.com/LK4D4/trylock v0.0.0-20191027065348-ff7e133a5c54/go.mod h1:uHbOgfPowb74TKlV4AR5Az2haG6evxzM8Lmj1Xil25E=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSiWQsof+nXEI9bUVUyV6F53Fp89EuCh2EAA=
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
@@ -62,6 +60,11 @@ github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kkdai/bstream v1.0.0 h1:Se5gHwgp2VT2uHfDrkbbgbgEvV9cimLELwrPJctSjg8=
 github.com/kkdai/bstream v1.0.0/go.mod h1:FDnDOHt5Yx4p3FaHcioFT0QjDOtgUpvjeZqAs+NVZZA=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lightningnetwork/lnd/queue v1.0.5-0.20201016111222-d12f76fd6d48 h1:rKaMViAN+42kv6oB1asYIr9UkUOadC2RSlaEP8yLSCc=
 github.com/lightningnetwork/lnd/queue v1.0.5-0.20201016111222-d12f76fd6d48/go.mod h1:YTkTVZCxz8tAYreH27EO3s8572ODumWrNdYW2E/YKxg=
 github.com/lightningnetwork/lnd/ticker v1.0.0 h1:S1b60TEGoTtCe2A0yeB+ecoj/kkS4qpwh6l+AkQEZwU=
@@ -169,8 +172,9 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -30,27 +30,27 @@ const (
 	// minInFlightBlocks is the minimum number of blocks that should be
 	// in the request queue for headers-first mode before requesting
 	// more.
-	minInFlightBlocks = 10
+	minInFlightBlocks = 12
 
 	// maxRejectedTxns is the maximum number of rejected transactions
 	// hashes to store in memory.
-	maxRejectedTxns = 1000
+	maxRejectedTxns = 1200
 
 	// maxRequestedBlocks is the maximum number of requested block
 	// hashes to store in memory.
-	maxRequestedBlocks = wire.MaxInvPerMsg
+	maxRequestedBlocks = (wire.MaxInvPerMsg - 100)
 
 	// maxRequestedTxns is the maximum number of requested transactions
 	// hashes to store in memory.
-	maxRequestedTxns = wire.MaxInvPerMsg
+	maxRequestedTxns = (wire.MaxInvPerMsg - 100)
 
 	// maxStallDuration is the time after which we will disconnect our
 	// current sync peer if we haven't made progress.
-	maxStallDuration = 3 * time.Minute
+	maxStallDuration = 2 * time.Minute
 
 	// stallSampleInterval the interval at which we will check to see if our
 	// sync has stalled.
-	stallSampleInterval = 30 * time.Second
+	stallSampleInterval = 10 * time.Second
 )
 
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -25,7 +25,7 @@ func mockRemotePeer() er.R {
 		UserAgentName:    "peer",  // User agent name to advertise.
 		UserAgentVersion: "1.0.0", // User agent version to advertise.
 		ChainParams:      &chaincfg.SimNetParams,
-		TrickleInterval:  time.Second * 10,
+		TrickleInterval:  time.Second * 15,
 	}
 
 	// Accept connections on the simnet port.

--- a/pktwallet/config.go
+++ b/pktwallet/config.go
@@ -484,6 +484,11 @@ func loadConfig() (*config, []string, er.R) {
 		return nil, nil, err
 	}
 
+	// Ensure the data directory for the network exists.
+	if err := checkCreateDir(netDir); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return nil, nil, err
+	}
 	if cfg.CreateTemp {
 		tempWalletExists := false
 
@@ -492,12 +497,6 @@ func loadConfig() (*config, []string, er.R) {
 				"wallet instead.")
 			fmt.Fprintln(os.Stdout, str)
 			tempWalletExists = true
-		}
-
-		// Ensure the data directory for the network exists.
-		if err := checkCreateDir(netDir); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			return nil, nil, err
 		}
 
 		if !tempWalletExists {
@@ -513,12 +512,6 @@ func loadConfig() (*config, []string, er.R) {
 		if dbFileExists {
 			err := er.Errorf("The wallet database file `%v` "+
 				"already exists.", dbPath)
-			fmt.Fprintln(os.Stderr, err)
-			return nil, nil, err
-		}
-
-		// Ensure the data directory for the network exists.
-		if err := checkCreateDir(netDir); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return nil, nil, err
 		}

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -2325,7 +2325,6 @@ func opcodeCheckMultiSig(op *parsescript.ParsedOpcode, vm *Engine) er.R {
 		if err := vm.checkPubKeyEncoding(pubKey); err != nil {
 			return err
 		}
-
 		// Parse the pubkey.
 		parsedPubKey, err := btcec.ParsePubKey(pubKey, btcec.S256())
 		if err != nil {
@@ -2350,7 +2349,6 @@ func opcodeCheckMultiSig(op *parsescript.ParsedOpcode, vm *Engine) er.R {
 		} else {
 			hash = calcSignatureHash(script, hashType, &vm.tx, vm.txIdx)
 		}
-
 		var valid bool
 		if vm.sigCache != nil {
 			var sigHash chainhash.Hash


### PR DESCRIPTION
* netsync/manager:
 1. faster stall detection
 2. attempt to avoid ban triggers

* peer/peer:
 1. additional locking
 2. only increase block height
 3. increase `DefaultTrickleInterval` time
 4. allow (and log) unhandled commands

* pktwallet/config:
 1. ensure data directory creation

* do:
 1. extensive additional error checking
 2. enhanced POSIX compliance **

* ** Explanation and rationale for `do` changes:

1. Switch to `env` to locate shell - `$SHELL` is non-standard (and there is no standard shell location in POSIX); you can use the `command -p getconf _POSIX_SHELL` command to check if a POSIX-compatible shell is supplied, but only `env` has a standardized location, so it can be used to find `sh`.

2. Strange use of `true :` is a workaround for known shell bugs and a no-op elsewhere.

3. `set -e` error handling is buggy on **most** shells - it's behavior varies so widely that it cannot be relied on, especially in combination with traps - manual error checking via `try()`/`die()` is a common and and reliable workaround, and the `just()` function allows a script to work the same both with and without -e error handling.

4. **`echo` must never be used and is nonstandard.**

"According to POSIX, `echo` has unspecified behavior if any of its arguments contain `“\”` or if it's first argument is “-n”. Various UNIX™ *"standards"* fill in this unspecified area for XSI-conformant implementations, by specifying nasty undesirable behavior that no one wants: (like `“\”` is interpreted as a C-string-literal style escape, for example), and other popular "standard" implementations such as Bash will interpret argument values other than `“-n”` as special options, even when with the dubious
*“POSIX compatibility”* mode enabled, rendering them non-conformant - ksh offers `"print"` which is very sane, but sadly, `ksh`-specific.

Due to these limitations, `echo` can only be reliably used in a very small number of cases, and only where you have strict guarantees about the contents of any variable being evaluated, including oddness that's easy to forget about, like the fact that the variable may not contain any non-negative integer, etc.

`say()` wrap's `printf` and just avoids all this idiocy.

5. All variables are modified via POSIX variable substutiton to be either defaulted or checked, making the script compatible with shells that default or enable the "set -u" option which modifies the checking in the shell's expansion
rules.

6. Some rather pedantic checks are enabled, such as checking the return levels for "export", as it may fail due to lack of environment space.

7. A wrapper is defined to use `command` whenever we can, to suppress the behavior of the POSIX lookup function 1.b. Command Search and Execution rules, to normalize error handling.

8. Where available (such as BSD or Linux systems), the "`stdbuf`" utility, and "`--line-buffered`" argument to grep are detected and enabled automatically, allowing "do" to specially disable output buffering, which provides slightly slower, but immediate feedback when filtering outputs.

9. `git diff --ignore-cr-at-eol` is used, so as to not fail when the source code is modified between Windows and UNIX systems, for example.

10. Since we now require Go 1.14+, we can use the automatic linker selection and trimpath to get closer to and even actually create static and (sometimes) reproducible binaries, on some, but not all platforms, using the internal Go linker where possible  (while still passing "-static" to the external linker if selected), and requesting builds with CGo disabled. If you're on a platform where Go would use the external linker, and that linker is GNU, then you do require additional flags to make reproducible
binaries, such as disabling generation of the GNU-Build-ID and other tweaks. This is **NOT** done currently, but will be available when the `magefile`-based build system lands.
