### PR TITLE
Massive improvement in bbolt/walletdb speed

### DIFF
--- a/neutrino/bamboozle_unit_test.go
+++ b/neutrino/bamboozle_unit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkt-cash/pktd/neutrino/headerfs"
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
 	"github.com/pkt-cash/pktd/wire"
+	"go.etcd.io/bbolt"
 )
 
 func decodeHashNoError(str string) *chainhash.Hash {
@@ -549,8 +550,10 @@ func runCheckCFCheckptSanityTestCase(t *testing.T, testCase *cfCheckptTestCase) 
 		t.Fatalf("Failed to create temporary directory: %s", er.E(errr))
 	}
 	defer os.RemoveAll(tempDir)
-
-	db, err := walletdb.Create("bdb", tempDir+"/weks.db")
+    opts := &bbolt.Options{
+        NoFreelistSync: true,    
+    }
+	db, err := walletdb.Create("bdb", tempDir+"/weks.db", opts)
 	if err != nil {
 		t.Fatalf("Error opening DB: %s", err)
 	}

--- a/neutrino/banman/store_test.go
+++ b/neutrino/banman/store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkt-cash/pktd/neutrino/banman"
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
 	_ "github.com/pkt-cash/pktd/pktwallet/walletdb/bdb"
+	"go.etcd.io/bbolt"
 )
 
 // createTestBanStore creates a test Store backed by a boltdb instance.
@@ -24,8 +25,10 @@ func createTestBanStore(t *testing.T) (banman.Store, func()) {
 		t.Fatalf("unable to create db dir: %v", er.E(errr))
 	}
 	dbPath := filepath.Join(dbDir, "test.db")
-
-	db, err := walletdb.Create("bdb", dbPath)
+    opts := &bbolt.Options{
+        NoFreelistSync: true,
+    }
+	db, err := walletdb.Create("bdb", dbPath, opts)
 	if err != nil {
 		os.RemoveAll(dbDir)
 		t.Fatalf("unable to create db: %v", err)

--- a/neutrino/blockmanager_test.go
+++ b/neutrino/blockmanager_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
 	"github.com/pkt-cash/pktd/txscript"
 	"github.com/pkt-cash/pktd/wire"
+	"go.etcd.io/bbolt"
 )
 
 // maxHeight is the height we will generate filter headers up to.
@@ -42,8 +43,10 @@ func setupBlockManager() (*blockManager, headerfs.BlockHeaderStore,
 		return nil, nil, nil, nil, er.Errorf("Failed to create "+
 			"temporary directory: %s", errr)
 	}
-
-	db, err := walletdb.Create("bdb", tempDir+"/weks.db")
+    opts := &bbolt.Options{
+        NoFreelistSync: true,
+    }
+	db, err := walletdb.Create("bdb", tempDir+"/weks.db", opts)
 	if err != nil {
 		os.RemoveAll(tempDir)
 		return nil, nil, nil, nil, er.Errorf("Error opening DB: %s",

--- a/neutrino/filterdb/db_test.go
+++ b/neutrino/filterdb/db_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkt-cash/pktd/chaincfg/chainhash"
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
 	_ "github.com/pkt-cash/pktd/pktwallet/walletdb/bdb"
+	"go.etcd.io/bbolt"
 )
 
 func createTestDatabase() (func(), FilterDatabase, er.R) {
@@ -22,8 +23,10 @@ func createTestDatabase() (func(), FilterDatabase, er.R) {
 	if errr != nil {
 		return nil, nil, er.E(errr)
 	}
-
-	db, err := walletdb.Create("bdb", tempDir+"/test.db")
+    opts := &bbolt.Options{
+        NoFreelistSync: true,
+    }
+	db, err := walletdb.Create("bdb", tempDir+"/test.db", opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/neutrino/headerfs/index_test.go
+++ b/neutrino/headerfs/index_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
 	_ "github.com/pkt-cash/pktd/pktwallet/walletdb/bdb"
+	"go.etcd.io/bbolt"
 )
 
 func createTestIndex() (func(), *headerIndex, er.R) {
@@ -18,8 +19,10 @@ func createTestIndex() (func(), *headerIndex, er.R) {
 	if errr != nil {
 		return nil, nil, er.E(errr)
 	}
-
-	db, err := walletdb.Create("bdb", tempDir+"/test.db")
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Create("bdb", tempDir+"/test.db", opts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/neutrino/headerfs/store_test.go
+++ b/neutrino/headerfs/store_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkt-cash/pktd/chaincfg/genesis"
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
 	"github.com/pkt-cash/pktd/wire"
+	"go.etcd.io/bbolt"
 )
 
 func createTestBlockHeaderStore() (func(), walletdb.DB, string,
@@ -27,9 +28,11 @@ func createTestBlockHeaderStore() (func(), walletdb.DB, string,
 	if errr != nil {
 		return nil, nil, "", nil, er.E(errr)
 	}
-
+    opts := &bbolt.Options{
+        NoFreelistSync: true,
+    }
 	dbPath := filepath.Join(tempDir, "test.db")
-	db, err := walletdb.Create("bdb", dbPath)
+	db, err := walletdb.Create("bdb", dbPath, opts)
 	if err != nil {
 		return nil, nil, "", nil, err
 	}
@@ -232,7 +235,10 @@ func createTestFilterHeaderStore() (func(), walletdb.DB, string, *FilterHeaderSt
 	}
 
 	dbPath := filepath.Join(tempDir, "test.db")
-	db, err := walletdb.Create("bdb", dbPath)
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Create("bdb", dbPath, opts)
 	if err != nil {
 		return nil, nil, "", nil, err
 	}
@@ -523,7 +529,6 @@ func TestFilterHeaderStateAssertion(t *testing.T) {
 
 	const chainTip = 10
 	filterHeaderChain := createTestFilterHeaderChain(chainTip)
-
 	setup := func(t *testing.T) (func(), string, walletdb.DB) {
 		cleanUp, db, tempDir, fhs, err := createTestFilterHeaderStore()
 		if err != nil {

--- a/pktwallet/btcwallet.go
+++ b/pktwallet/btcwallet.go
@@ -75,7 +75,7 @@ func walletMain() er.R {
 	}
 
 	dbDir := networkDir(cfg.AppDataDir.Value, activeNet.Params)
-	loader := wallet.NewLoader(activeNet.Params, dbDir, cfg.Wallet, 250)
+	loader := wallet.NewLoader(activeNet.Params, dbDir, cfg.Wallet, true, 250)
 
 	// Create and start HTTP server to serve wallet client connections.
 	// This will be updated with the wallet and chain server RPC client

--- a/pktwallet/waddrmgr/common_test.go
+++ b/pktwallet/waddrmgr/common_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkt-cash/pktd/chaincfg"
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
 	_ "github.com/pkt-cash/pktd/pktwallet/walletdb/bdb"
+	"go.etcd.io/bbolt"
 )
 
 var (
@@ -225,7 +226,10 @@ func emptyDB(t *testing.T) (tearDownFunc func(), db walletdb.DB) {
 		t.Fatalf("Failed to create db temp dir: %v", errr)
 	}
 	dbPath := filepath.Join(dirName, "mgrtest.db")
-	db, err := walletdb.Create("bdb", dbPath)
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Create("bdb", dbPath, opts)
 	if err != nil {
 		_ = os.RemoveAll(dirName)
 		t.Fatalf("createDbNamespace: unexpected error: %v", err)
@@ -246,7 +250,10 @@ func setupManager(t *testing.T) (tearDownFunc func(), db walletdb.DB, mgr *Manag
 		t.Fatalf("Failed to create db temp dir: %v", errr)
 	}
 	dbPath := filepath.Join(dirName, "mgrtest.db")
-	db, err := walletdb.Create("bdb", dbPath)
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Create("bdb", dbPath, opts)
 	if err != nil {
 		_ = os.RemoveAll(dirName)
 		t.Fatalf("createDbNamespace: unexpected error: %v", err)

--- a/pktwallet/waddrmgr/manager_test.go
+++ b/pktwallet/waddrmgr/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkt-cash/pktd/chaincfg/chainhash"
 	"github.com/pkt-cash/pktd/pktwallet/snacl"
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
+	"go.etcd.io/bbolt"
 )
 
 // failingCryptoKey is an implementation of the EncryptorDecryptor interface
@@ -1615,7 +1616,10 @@ func testWatchingOnly(tc *testContext) bool {
 	defer os.Remove(woMgrName)
 
 	// Open the new database copy and get the address manager namespace.
-	db, err := walletdb.Open("bdb", woMgrName)
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Open("bdb", woMgrName, opts)
 	if err != nil {
 		tc.t.Errorf("openDbNamespace: unexpected error: %v", err)
 		return false

--- a/pktwallet/wallet/createtx_test.go
+++ b/pktwallet/wallet/createtx_test.go
@@ -43,7 +43,7 @@ func TestTxToOutputsDryRun(t *testing.T) {
 	pubPass := []byte("hello")
 	privPass := []byte("world")
 
-	loader := NewLoader(&chaincfg.TestNet3Params, dir, "wallet.db", 250)
+	loader := NewLoader(&chaincfg.TestNet3Params, dir, "wallet.db", true, 250)
 	w, err := loader.CreateNewWallet(pubPass, privPass, []byte(hex.EncodeToString(seed)), nil)
 	if err != nil {
 		t.Fatalf("unable to create wallet: %v", err)

--- a/pktwallet/walletdb/bdb/db.go
+++ b/pktwallet/walletdb/bdb/db.go
@@ -373,11 +373,20 @@ func fileExists(name string) bool {
 
 // openDB opens the database at the provided path.  walletdb.ErrDbDoesNotExist
 // is returned if the database doesn't exist and the create flag is not set.
-func openDB(dbPath string, create bool) (walletdb.DB, er.R) {
+func openDB(dbPath string, create bool, options *bbolt.Options) (walletdb.DB, er.R) {
 	if !create && !fileExists(dbPath) {
 		return nil, walletdb.ErrDbDoesNotExist.Default()
+		dbFileInfo, err := os.Stat(dbPath)
+		dbFileSize := dbFileInfo.Size()
+		if err != nil {
+			return nil, convertErr(err)
+		}
+		options = &bbolt.Options{
+			NoFreelistSync:  true,
+			InitialMmapSize: int(dbFileSize * 2),
+			FreelistType:    bbolt.FreelistMapType,
+		}
 	}
-
-	boltDB, err := bbolt.Open(dbPath, 0600, nil)
+	boltDB, err := bbolt.Open(dbPath, 0600, options)
 	return (*db)(boltDB), convertErr(err)
 }

--- a/pktwallet/walletdb/bdb/driver_test.go
+++ b/pktwallet/walletdb/bdb/driver_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
 	_ "github.com/pkt-cash/pktd/pktwallet/walletdb/bdb"
+
+	"go.etcd.io/bbolt"
 )
 
 // dbType is the database type name for this driver.
@@ -21,10 +23,13 @@ const dbType = "bdb"
 // TestCreateOpenFail ensures that errors related to creating and opening a
 // database are handled properly.
 func TestCreateOpenFail(t *testing.T) {
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
 	// Ensure that attempting to open a database that doesn't exist returns
 	// the expected error.
 	wantErr := walletdb.ErrDbDoesNotExist.Default()
-	if _, err := walletdb.Open(dbType, "noexist.db"); !er.Equals(err, wantErr) {
+	if _, err := walletdb.Open(dbType, "noexist.db", opts); !er.Equals(err, wantErr) {
 		t.Errorf("Open: did not receive expected error - got %v, "+
 			"want %v", err, wantErr)
 		return
@@ -33,7 +38,7 @@ func TestCreateOpenFail(t *testing.T) {
 	// Ensure that attempting to open a database with the wrong number of
 	// parameters returns the expected error.
 	wantErr = er.Errorf("invalid arguments to %s.Open -- expected "+
-		"database path", dbType)
+		"database path and *bbolt.Option option", dbType)
 	if _, err := walletdb.Open(dbType, 1, 2, 3); err.Message() != wantErr.Message() {
 		t.Errorf("Open: did not receive expected error - got %v, "+
 			"want %v", err, wantErr)
@@ -42,8 +47,8 @@ func TestCreateOpenFail(t *testing.T) {
 
 	// Ensure that attempting to open a database with an invalid type for
 	// the first parameter returns the expected error.
-	wantErr = er.Errorf("first argument to %s.Open is invalid -- "+
-		"expected database path string", dbType)
+	wantErr = er.Errorf("invalid arguments to bdb.Open -- "+
+		"expected database path and *bbolt.Option option")
 	if _, err := walletdb.Open(dbType, 1); err.Message() != wantErr.Message() {
 		t.Errorf("Open: did not receive expected error - got %v, "+
 			"want %v", err, wantErr)
@@ -53,7 +58,7 @@ func TestCreateOpenFail(t *testing.T) {
 	// Ensure that attempting to create a database with the wrong number of
 	// parameters returns the expected error.
 	wantErr = er.Errorf("invalid arguments to %s.Create -- expected "+
-		"database path", dbType)
+		"database path and *bbolt.Option option", dbType)
 	if _, err := walletdb.Create(dbType, 1, 2, 3); err.Message() != wantErr.Message() {
 		t.Errorf("Create: did not receive expected error - got %v, "+
 			"want %v", err, wantErr)
@@ -62,8 +67,8 @@ func TestCreateOpenFail(t *testing.T) {
 
 	// Ensure that attempting to open a database with an invalid type for
 	// the first parameter returns the expected error.
-	wantErr = er.Errorf("first argument to %s.Create is invalid -- "+
-		"expected database path string", dbType)
+	wantErr = er.Errorf("invalid arguments to bdb.Create -- "+
+		"expected database path and *bbolt.Option option")
 	if _, err := walletdb.Create(dbType, 1); err.Message() != wantErr.Message() {
 		t.Errorf("Create: did not receive expected error - got %v, "+
 			"want %v", err, wantErr)
@@ -73,7 +78,7 @@ func TestCreateOpenFail(t *testing.T) {
 	// Ensure operations against a closed database return the expected
 	// error.
 	dbPath := "createfail.db"
-	db, err := walletdb.Create(dbType, dbPath)
+	db, err := walletdb.Create(dbType, dbPath, opts)
 	if err != nil {
 		t.Errorf("Create: unexpected error: %v", err)
 		return
@@ -92,9 +97,12 @@ func TestCreateOpenFail(t *testing.T) {
 // TestPersistence ensures that values stored are still valid after closing and
 // reopening the database.
 func TestPersistence(t *testing.T) {
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
 	// Create a new database to run tests against.
 	dbPath := "persistencetest.db"
-	db, err := walletdb.Create(dbType, dbPath)
+	db, err := walletdb.Create(dbType, dbPath, opts)
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return
@@ -131,7 +139,7 @@ func TestPersistence(t *testing.T) {
 
 	// Close and reopen the database to ensure the values persist.
 	db.Close()
-	db, err = walletdb.Open(dbType, dbPath)
+	db, err = walletdb.Open(dbType, dbPath, opts)
 	if err != nil {
 		t.Errorf("Failed to open test database (%s) %v", dbType, err)
 		return

--- a/pktwallet/walletdb/bdb/interface_test.go
+++ b/pktwallet/walletdb/bdb/interface_test.go
@@ -12,16 +12,31 @@
 
 package bdb_test
 
+
 import (
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/pkt-cash/pktd/pktwallet/walletdb/walletdbtest"
+	"go.etcd.io/bbolt"
 )
 
 // TestInterface performs all interfaces tests for this database driver.
 func TestInterface(t *testing.T) {
-	dbPath := "interfacetest.db"
+	tempDir, err := ioutil.TempDir("", "interfacetest")
+	if err != nil {
+		t.Errorf("unable to create temp dir: %v", err)
+		return
+	}
+	defer os.Remove(tempDir)
+
+	dbPath := filepath.Join(tempDir, "db")
 	defer os.RemoveAll(dbPath)
-	walletdbtest.TestInterface(t, dbType, dbPath)
+
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	walletdbtest.TestInterface(t, dbType, dbPath, opts)
 }

--- a/pktwallet/walletdb/db_test.go
+++ b/pktwallet/walletdb/db_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
 	_ "github.com/pkt-cash/pktd/pktwallet/walletdb/bdb"
+	"go.etcd.io/bbolt"
 )
 
 // TestAddDuplicateDriver ensures that adding a duplicate driver does not
@@ -46,9 +47,11 @@ func TestAddDuplicateDriver(t *testing.T) {
 		t.Errorf("unexpected duplicate driver registration error - "+
 			"got %v, want %v", err, walletdb.ErrDbTypeRegistered)
 	}
-
 	dbPath := "dupdrivertest.db"
-	db, err := walletdb.Create(dbType, dbPath)
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Create(dbType, dbPath, opts)
 	if err != nil {
 		t.Errorf("failed to create database: %v", err)
 		return
@@ -82,7 +85,10 @@ func TestCreateOpenFail(t *testing.T) {
 
 	// Ensure creating a database with the new type fails with the expected
 	// error.
-	_, err := walletdb.Create(dbType)
+	opts := &bbolt.Options{
+        NoFreelistSync: true,
+    }
+	_, err := walletdb.Create(dbType, opts)
 	if err.String() != openError.String() {
 		t.Errorf("expected error not received - got: %v, want %v", err,
 			openError)
@@ -91,7 +97,7 @@ func TestCreateOpenFail(t *testing.T) {
 
 	// Ensure opening a database with the new type fails with the expected
 	// error.
-	_, err = walletdb.Open(dbType)
+	_, err = walletdb.Open(dbType, opts)
 	if err.String() != openError.String() {
 		t.Errorf("expected error not received - got: %v, want %v", err,
 			openError)
@@ -105,7 +111,10 @@ func TestCreateOpenUnsupported(t *testing.T) {
 	// Ensure creating a database with an unsupported type fails with the
 	// expected error.
 	dbType := "unsupported"
-	_, err := walletdb.Create(dbType)
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	_, err := walletdb.Create(dbType, opts)
 	if !walletdb.ErrDbUnknownType.Is(err) {
 		t.Errorf("expected error not received - got: %v, want %v", err,
 			walletdb.ErrDbUnknownType)
@@ -114,7 +123,7 @@ func TestCreateOpenUnsupported(t *testing.T) {
 
 	// Ensure opening a database with the an unsupported type fails with the
 	// expected error.
-	_, err = walletdb.Open(dbType)
+	_, err = walletdb.Open(dbType, opts)
 	if !walletdb.ErrDbUnknownType.Is(err) {
 		t.Errorf("expected error not received - got: %v, want %v", err,
 			walletdb.ErrDbUnknownType)

--- a/pktwallet/walletdb/example_test.go
+++ b/pktwallet/walletdb/example_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkt-cash/pktd/btcutil/er"
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
 	_ "github.com/pkt-cash/pktd/pktwallet/walletdb/bdb"
+	"go.etcd.io/bbolt"
 )
 
 // This example demonstrates creating a new database.
@@ -29,7 +30,10 @@ func ExampleCreate() {
 	// this, but it's done here in the example to ensure the example cleans
 	// up after itself.
 	dbPath := filepath.Join(os.TempDir(), "examplecreate.db")
-	db, err := walletdb.Create("bdb", dbPath)
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Create("bdb", dbPath, opts)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -48,7 +52,10 @@ var exampleNum = 0
 func exampleLoadDB() (walletdb.DB, func(), er.R) {
 	dbName := fmt.Sprintf("exampleload%d.db", exampleNum)
 	dbPath := filepath.Join(os.TempDir(), dbName)
-	db, err := walletdb.Create("bdb", dbPath)
+		opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Create("bdb", dbPath, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -112,7 +119,10 @@ func Example_basicUsage() {
 	// this, but it's done here in the example to ensure the example cleans
 	// up after itself.
 	dbPath := filepath.Join(os.TempDir(), "exampleusage.db")
-	db, err := walletdb.Create("bdb", dbPath)
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Create("bdb", dbPath, opts)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/pktwallet/walletdb/walletdbtest/interface.go
+++ b/pktwallet/walletdb/walletdbtest/interface.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkt-cash/pktd/btcutil/er"
 
 	"github.com/pkt-cash/pktd/pktwallet/walletdb"
+	"go.etcd.io/bbolt"
 )
 
 // errSubTestFail is used to signal that a sub test returned false.
@@ -675,8 +676,8 @@ func testAdditionalErrors(tc *testContext) bool {
 }
 
 // TestInterface performs all interfaces tests for this database driver.
-func TestInterface(t Tester, dbType, dbPath string) {
-	db, err := walletdb.Create(dbType, dbPath)
+func TestInterface(t Tester, dbType, dbPath string, opts *bbolt.Options) {
+	db, err := walletdb.Create(dbType, dbPath, opts)
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return

--- a/pktwallet/walletsetup.go
+++ b/pktwallet/walletsetup.go
@@ -116,7 +116,7 @@ type WalletSetupCfg struct {
 // provided path.
 func createWallet(cfg *config) er.R {
 	dbDir := networkDir(cfg.AppDataDir.Value, activeNet.Params)
-	loader := wallet.NewLoader(activeNet.Params, dbDir, cfg.Wallet, 250)
+	loader := wallet.NewLoader(activeNet.Params, dbDir, cfg.Wallet, true, 250)
 
 	// When there is a legacy keystore, open it now to ensure any errors
 	// don't end up exiting the process after the user has spent time

--- a/pktwallet/wtxmgr/tx_test.go
+++ b/pktwallet/wtxmgr/tx_test.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/pkt-cash/pktd/pktwallet/walletdb/bdb"
 	"github.com/pkt-cash/pktd/wire"
 	"github.com/pkt-cash/pktd/wire/constants"
+	"go.etcd.io/bbolt"
 )
 
 // Received transaction output for mainnet outpoint
@@ -51,7 +52,10 @@ func testDB() (walletdb.DB, func(), er.R) {
 	if errr != nil {
 		return nil, func() {}, er.E(errr)
 	}
-	db, err := walletdb.Create("bdb", filepath.Join(tmpDir, "db"))
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Create("bdb", filepath.Join(tmpDir, "db"), opts)
 	return db, func() { os.RemoveAll(tmpDir) }, err
 }
 
@@ -62,8 +66,10 @@ func testStore() (*Store, walletdb.DB, func(), er.R) {
 	if errr != nil {
 		return nil, nil, func() {}, er.E(errr)
 	}
-
-	db, err := walletdb.Create("bdb", filepath.Join(tmpDir, "db"))
+	opts := &bbolt.Options{
+		NoFreelistSync: true,
+	}
+	db, err := walletdb.Create("bdb", filepath.Join(tmpDir, "db"), opts)
 	if err != nil {
 		os.RemoveAll(tmpDir)
 		return nil, nil, nil, err


### PR DESCRIPTION
* ﻿First, we take the size of the walletdb and set our initial mmap size to (current size * 2) - this will reduces the amount of re-mapping that needs to be done at doubling and also reduces memory fragmentation - actual results is less memory usage, though higher usage initially.

* Also enable the NoFreelistSync option to not sync the freelist to disk, which has a massive improvement on write performance.

* Combined, tests on a Gridnode show a 250% gain.
