### PR TITLE
Attempt to increase robustness; avoid bans.

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -34,23 +34,23 @@ const (
 
 	// maxRejectedTxns is the maximum number of rejected transactions
 	// hashes to store in memory.
-	maxRejectedTxns = 1000
+	maxRejectedTxns = 1200
 
 	// maxRequestedBlocks is the maximum number of requested block
 	// hashes to store in memory.
-	maxRequestedBlocks = wire.MaxInvPerMsg
+	maxRequestedBlocks = (wire.MaxInvPerMsg - 100)
 
 	// maxRequestedTxns is the maximum number of requested transactions
 	// hashes to store in memory.
-	maxRequestedTxns = wire.MaxInvPerMsg
+	maxRequestedTxns = (wire.MaxInvPerMsg - 100)
 
 	// maxStallDuration is the time after which we will disconnect our
 	// current sync peer if we haven't made progress.
-	maxStallDuration = 3 * time.Minute
+	maxStallDuration = 1 * time.Minute
 
 	// stallSampleInterval the interval at which we will check to see if our
 	// sync has stalled.
-	stallSampleInterval = 30 * time.Second
+	stallSampleInterval = 10 * time.Second
 )
 
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -33,23 +33,30 @@ const (
 	minInFlightBlocks = 10
 
 	// maxRejectedTxns is the maximum number of rejected transactions
-	// hashes to store in memory.
+	// hashes to store in memory. 
 	maxRejectedTxns = 1200
 
 	// maxRequestedBlocks is the maximum number of requested block
-	// hashes to store in memory.
+	// hashes to store in memory. By requesting 100 less than the
+	// maximum, we avoid immediately triggering the remote peers ban
+	// manager when our connection is fast or latency is very low.
 	maxRequestedBlocks = (wire.MaxInvPerMsg - 100)
 
 	// maxRequestedTxns is the maximum number of requested transactions
-	// hashes to store in memory.
+	// hashes to store in memory. By requesting 100 less than the
+	// maximum, we avoid immediately triggering the remote peers ban
+	// manager when our connection is fast or latency is very low.
 	maxRequestedTxns = (wire.MaxInvPerMsg - 100)
 
 	// maxStallDuration is the time after which we will disconnect our
-	// current sync peer if we haven't made progress.
+	// current sync peer if we haven't made progress. For PKTD, it's
+	// not unreasonable to expect progress within one minute vs. the
+	// default of three minutes due the use of meshnet connections.
 	maxStallDuration = 1 * time.Minute
 
-	// stallSampleInterval the interval at which we will check to see if our
-	// sync has stalled.
+	// stallSampleInterval the interval at which we will check to see
+	// if our sync has stalled. Checking at 10 second intervals is the
+	// maximum possible without any noticeable performance penalties.
 	stallSampleInterval = 10 * time.Second
 )
 

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -25,7 +25,7 @@ func mockRemotePeer() er.R {
 		UserAgentName:    "peer",  // User agent name to advertise.
 		UserAgentVersion: "1.0.0", // User agent version to advertise.
 		ChainParams:      &chaincfg.SimNetParams,
-		TrickleInterval:  time.Second * 10,
+		TrickleInterval:  time.Second * 15,
 	}
 
 	// Accept connections on the simnet port.

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -25,7 +25,7 @@ func mockRemotePeer() er.R {
 		UserAgentName:    "peer",  // User agent name to advertise.
 		UserAgentVersion: "1.0.0", // User agent version to advertise.
 		ChainParams:      &chaincfg.SimNetParams,
-		TrickleInterval:  time.Second * 15,
+		TrickleInterval:  time.Second * 5,
 	}
 
 	// Accept connections on the simnet port.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -35,7 +35,16 @@ const (
 
 	// DefaultTrickleInterval is the min time between attempts to send an
 	// inv message to a peer.
-	DefaultTrickleInterval = 15 * time.Second
+	//
+	// The BTCD default is 10 - this controls the wait before nodes send
+	// more txns at once and reduces the time new txns have to wait before
+	// before being broadcast - with the previous settings, the maximum a
+	// single node could send would be about ~28MB worth of txns every ten
+	// minutes - XXX(trn) I'm investigating the effects of removing the
+	// trickling concept all-together and attempting to broadcast all txns
+	// immediately, but it would require some extra peer selection logic,
+	// rather than just rebroadcasting txns to connected peers at random.
+	DefaultTrickleInterval = 5 * time.Second
 
 	// MinAcceptableProtocolVersion is the lowest protocol version that a
 	// connected peer may support.

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -35,7 +35,7 @@ const (
 
 	// DefaultTrickleInterval is the min time between attempts to send an
 	// inv message to a peer.
-	DefaultTrickleInterval = 10 * time.Second
+	DefaultTrickleInterval = 15 * time.Second
 
 	// MinAcceptableProtocolVersion is the lowest protocol version that a
 	// connected peer may support.
@@ -577,10 +577,10 @@ func (p *Peer) UpdateLastBlockHeight(newHeight int32) {
 		p.statsMtx.Unlock()
 		return
 	}
+	defer p.statsMtx.Unlock()
 	log.Tracef("Updating last block height of peer %v from %v to %v",
 		p.addr, p.lastBlock, newHeight)
 	p.lastBlock = newHeight
-	p.statsMtx.Unlock()
 }
 
 // UpdateLastAnnouncedBlock updates meta-data about the last block hash this
@@ -1416,7 +1416,7 @@ out:
 			// disconnect the peer when we're in regression test mode and the
 			// error is one of the allowed errors.
 			if p.isAllowedReadError(err) {
-				log.Errorf("Allowed test error from %s: %v", p, err)
+				log.Errorf("Allowed read error from %s: %v", p, err)
 				idleTimer.Reset(idleTimeout)
 				continue
 			}


### PR DESCRIPTION
* netmgr: Attempt to avoid ban trigger conditions.
* netmgr: Faster stall detection of stuck peers.

* peer: Improve locking in `UpdateLastBlockHeight`.
* peer: Increase `DefaultTrickleInterval` time.
