### PR TITLE
 Enhancements to `do` build script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 go: 1.15.3
+git:
+    depth: false
 env:
   - PKT_FAIL_DIRTY=1
 jobs:

--- a/do
+++ b/do
@@ -1,25 +1,19 @@
-#!/bin/sh
-die() { echo $1; exit 1; }
+#!/usr/bin/env sh  
+die() { printf '%s\n' "$*" >&2; exit 1; }
 export GO111MODULE=on
-PKTD_GIT_ID=$(git describe --tags HEAD)
-if ! git diff --quiet; then
-    if test "x$PKT_FAIL_DIRTY" != x; then
-        echo "Build is dirty, failing"
-        git diff
-        exit 1;
-    fi
-    PKTD_GIT_ID="${PKTD_GIT_ID}-dirty"
+PKTD_GIT_ID=$(git update-index -q --refresh 2>/dev/null; git describe --tags --dirty 2>/dev/null)
+if [ -n "${PKT_FAIL_DIRTY:-}" ]; then
+	{ export GIT_PAGER=cat; git diff && die "Build is dirty, aborting."; };
 fi
-PKTD_LDFLAGS="-X github.com/pkt-cash/pktd/pktconfig/version.appBuild=${PKTD_GIT_ID}"
-
-mkdir -p ./bin
-echo "Building pktd"
-go build -ldflags="${PKTD_LDFLAGS}" -o ./bin/pktd || die "failed to build pktd"
-echo "Building wallet"
-go build -ldflags="${PKTD_LDFLAGS}" -o ./bin/pktwallet ./pktwallet || die "failed to build wallet"
-echo "Building btcctl"
-go build -ldflags="${PKTD_LDFLAGS}" -o ./bin/pktctl ./cmd/btcctl || die "failed to build pktctl"
-echo "Running tests"
-go test ./... || die "tests failed"
-./bin/pktd --version || die "can't run pktd"
-echo "Everything looks good - use ./bin/pktd to launch"
+PKTD_LDFLAGS="-X github.com/pkt-cash/pktd/pktconfig/version.appBuild=${PKTD_GIT_ID:?"Failed to generate PKTD_GIT_ID, aborting."}"
+mkdir -p ./bin || die "Failed to create output directory, aborting."
+printf '%s\n' "Building pktd"
+go build -ldflags="${PKTD_LDFLAGS:?}" -o ./bin/pktd || die "Failed to build pktd, aborting."
+printf '%s\n' "Building wallet"
+go build -ldflags="${PKTD_LDFLAGS:?}" -o ./bin/pktwallet ./pktwallet || die "Failed to build wallet, aborting."
+printf '%s\n' "Building btcctl"
+go build -ldflags="${PKTD_LDFLAGS:?}" -o ./bin/pktctl ./cmd/btcctl || die "Failed to build pktctl, aborting."
+printf '%s\n' "Running tests"
+go test ./... || die "Tests failed, aborting."
+./bin/pktd --version || die "Unable to execute pktd, aborting."
+printf '%s\n' "Everything looks good - use ./bin/pktd to launch"


### PR DESCRIPTION
﻿* Use `env` to locate the interpreter

* Fully POSIX complaint use of `printf`

* Ensure errors are printed to stderr

* Verification of variable assignments

* Ensure output directory is created

* When `PKT_FAIL_DIRTY` is set, detect failure to generate a `PKTD_GIT_ID` (such as on a shallow clone)

* Specific Git compatability back to v1.7

* Passes `shellcheck -a --shell=sh --enable=all --severity=style`

* Shorter than original `do` by **5** lines of code

* 20% larger: *1103 vs. 891* characters

* Works on more systems, such as AIX 5L

* Only `go`, `git`, and `cat` are not POSIX shell built-in functions

* Tested on ash, dash, zsh, mksh, lksh, ksh93, ksh-2000, ksh-2020, OpenKSH, bash, OpenBSD ksh, bosh, and Heirloom sh

* No changes to build flags or logic

* **All further build system work will be implemented in Go with** **`mage`**
