### PR TITLE
Fix a spurious warning message

### DIFF
--- a/cmd/btcctl/config.go
+++ b/cmd/btcctl/config.go
@@ -249,7 +249,9 @@ func loadConfig() (*config, []string, er.R) {
 		if preCfg.Wallet {
 			dir = pktwalletHomeDir
 		}
-		fmt.Fprintf(os.Stderr, "Warning: unable to get rpc password from path [%s]\n", dir)
+		if cfg.RPCPassword != "" {
+			fmt.Fprintf(os.Stderr, "Warning: unable to get rpc password from path [%s]\n", dir)
+		}
 	} else {
 		cfg.RPCUser = userpass[0]
 		cfg.RPCPassword = userpass[1]


### PR DESCRIPTION
Fixes a spurious warning message. In the case where `pktctl` is being used to control a `pktd` and/or `pktwallet` process not owned by the current user (but obviously on the same system), with any necessary RPC parameters specified as command-line options, then no warning message should be printed about being unable to read the RPC password from the users `$HOME/.pktwallet` directory - simply check to see if a password was specified before warning about it.
```
 » pktctl --notls --rpcuser=XXXX --rpcpass=XXXX --wallet getbalance
Warning: unable to get rpc password from path [/home/myuser/.pktwallet]
3031.8219427987933
```
With the patch:
```
 » pktctl --notls --rpcuser=XXXX --rpcpass=XXXX --wallet getbalance
3032.8619421137921
```
In this case, `pktd` is running as user `pktd_` and `pktwallet` is running as user `pktw_`, and the user executing `pktctl` has neither a `$HOME/.pktd` or a `$HOME/.pktwallet` directory, nor is their existence necessary.