### PR TITLE
LevelDB tuning; increase unclean shutdown robustness; reduce memory usage

### DIFF
--- a/database/ffldb/dbcache.go
+++ b/database/ffldb/dbcache.go
@@ -20,12 +20,19 @@ import (
 
 const (
 	// defaultCacheSize is the default size for the database cache.
-	defaultCacheSize = 10 * 1024 * 1024 // 10 MB
+	// The 4MB is derived from analysis of actual metadata size,
+	// and would be sufficient to cache the full metadata of one
+	// block in 99% of the cases - and only rarely in actual use is
+	// there concurrent access to multiple blocks, outside of being
+	// a sync peer or acting as a server to multiple SPV clients.
+	defaultCacheSize = 4 * 1024 * 1024 // 4 MB
 
 	// defaultFlushSecs is the default number of seconds to use as a
 	// threshold in between database cache flushes when the cache size has
-	// not been exceeded.
-	defaultFlushSecs = 60 // 1 minute
+	// not been exceeded. The 5 second number has less than a 10% hit on
+	// performance in testing and makes the metadata more resilient in
+	// the cases such as unplanned hard shutdowns or unexpected power loss.
+	defaultFlushSecs = 5 // 5 seconds
 )
 
 // ldbCacheIter wraps a treap iterator to provide the additional functionality

--- a/goleveldb/leveldb/opt/options.go
+++ b/goleveldb/leveldb/opt/options.go
@@ -23,7 +23,7 @@ const (
 
 var (
 	DefaultBlockCacher                   = LRUCacher
-	DefaultBlockCacheCapacity            = 8 * MiB
+	DefaultBlockCacheCapacity            = 4 * MiB
 	DefaultBlockRestartInterval          = 16
 	DefaultBlockSize                     = 4 * KiB
 	DefaultCompactionExpandLimitFactor   = 25
@@ -32,13 +32,13 @@ var (
 	DefaultCompactionSourceLimitFactor   = 1
 	DefaultCompactionTableSize           = 2 * MiB
 	DefaultCompactionTableSizeMultiplier = 1.0
-	DefaultCompactionTotalSize           = 10 * MiB
+	DefaultCompactionTotalSize           = 12 * MiB
 	DefaultCompactionTotalSizeMultiplier = 10.0
 	DefaultCompressionType               = SnappyCompression
 	DefaultIteratorSamplingRate          = 1 * MiB
 	DefaultOpenFilesCacher               = LRUCacher
 	DefaultWriteBuffer                   = 4 * MiB
-	DefaultWriteL0PauseTrigger           = 12
+	DefaultWriteL0PauseTrigger           = 10
 	DefaultWriteL0SlowdownTrigger        = 8
 	DefaultFilterBaseLg                  = 11
 )


### PR DESCRIPTION
﻿Some additional tuning of the LevelDB parameters to increase robustness in the cases of hard shutdowns or power failures, and to reduce memory used for caching. Initial benchmarks showing performance loss of under 10% for the entire blockchain.
