### PR TITLE
Peer P2P and network optimizations

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,8 +43,8 @@ const (
 	defaultLogFilename           = "pktd.log"
 	defaultMaxPeers              = 125
 	defaultBanDuration           = time.Hour * 24
-	defaultBanThreshold          = 100
-	defaultConnectTimeout        = time.Second * 30
+	defaultBanThreshold          = 120
+	defaultConnectTimeout        = time.Second * 10
 	defaultMaxRPCClients         = 10
 	defaultMaxRPCWebsockets      = 25
 	defaultMaxRPCConcurrentReqs  = 20

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -25,7 +25,7 @@ func mockRemotePeer() er.R {
 		UserAgentName:    "peer",  // User agent name to advertise.
 		UserAgentVersion: "1.0.0", // User agent version to advertise.
 		ChainParams:      &chaincfg.SimNetParams,
-		TrickleInterval:  time.Second * 5,
+		TrickleInterval:  time.Second * 2,
 	}
 
 	// Accept connections on the simnet port.
@@ -72,7 +72,7 @@ func Example_newOutboundPeer() {
 		UserAgentVersion: "1.0.0", // User agent version to advertise.
 		ChainParams:      &chaincfg.SimNetParams,
 		Services:         0,
-		TrickleInterval:  time.Second * 10,
+		TrickleInterval:  time.Second * 2,
 		Listeners: peer.MessageListeners{
 			OnVersion: func(p *peer.Peer, msg *wire.MsgVersion) *wire.MsgReject {
 				fmt.Println("outbound: received version")

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -239,7 +239,7 @@ func TestPeerConnection(t *testing.T) {
 		ChainParams:       &chaincfg.MainNetParams,
 		ProtocolVersion:   protocol.RejectVersion, // Configure with older version
 		Services:          0,
-		TrickleInterval:   time.Second * 10,
+		TrickleInterval:   time.Second * 2,
 	}
 	peer2Cfg := &peer.Config{
 		Listeners:         peer1Cfg.Listeners,
@@ -248,7 +248,7 @@ func TestPeerConnection(t *testing.T) {
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &chaincfg.MainNetParams,
 		Services:          protocol.SFNodeNetwork | protocol.SFNodeWitness,
-		TrickleInterval:   time.Second * 10,
+		TrickleInterval:   time.Second * 2,
 	}
 
 	wantStats1 := peerStats{
@@ -453,7 +453,7 @@ func TestPeerListeners(t *testing.T) {
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &chaincfg.MainNetParams,
 		Services:          protocol.SFNodeBloom,
-		TrickleInterval:   time.Second * 10,
+		TrickleInterval:   time.Second * 2,
 	}
 	inConn, outConn := pipe(
 		&conn{raddr: "10.0.0.1:8333"},
@@ -624,7 +624,7 @@ func TestOutboundPeer(t *testing.T) {
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &chaincfg.MainNetParams,
 		Services:          0,
-		TrickleInterval:   time.Second * 10,
+		TrickleInterval:   time.Second * 2,
 	}
 
 	r, w := io.Pipe()
@@ -765,7 +765,7 @@ func TestUnsupportedVersionPeer(t *testing.T) {
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &chaincfg.MainNetParams,
 		Services:          0,
-		TrickleInterval:   time.Second * 10,
+		TrickleInterval:   time.Second * 2,
 	}
 
 	localNA := wire.NewNetAddressIPPort(


### PR DESCRIPTION
 * Reduce the default ban threshold, to more closely match the behavior of the Satoshi Bitcoin Core software.

 * Reduce the time-out for connections and negotiation time, to be closer to, but not as low as, the Satoshi Bitcoin Core software, which uses a 5s default. 10s was chosen due to the fact this is a tunable which Bitcoin Core end-users are often known to increase to connect more easily to remote peers.

 * Further reduce default trickle delay *(to 2s)*, with full rationale and explanations in the comments.

 * Adjust all tests to run with the new defaults.
