### PR TITLE
Shutdown gracefully in 2 minutes or less ....

### DIFF
--- a/btcd.go
+++ b/btcd.go
@@ -154,8 +154,8 @@ func pktdMain(serverChan chan<- *server) er.R {
 		return err
 	}
 	defer func() {
-		// Shut down in 1 minute, or just pull the plug.
-		const shutdownTimeout = 1 * time.Minute
+		// Shut down in21 minutes, or just pull the plug.
+		const shutdownTimeout = 2 * time.Minute
 		pktdLog.Infof("Attempting graceful shutdown (%s timeout)...", shutdownTimeout)
 		server.Stop()
 		shutdownDone := make(chan struct{})
@@ -169,10 +169,8 @@ func pktdMain(serverChan chan<- *server) er.R {
 		case <-time.Tick(shutdownTimeout):
 		pktdLog.Errorf("Graceful shutdown in %s failed - forcefully terminating in 5s...", shutdownTimeout)
 		time.Sleep(5 * time.Second)
-		// Are we still here?
 		panic("Forcefully terminating the server process...")
 		}
-		// We did it!
 		srvrLog.Infof("Server shutdown complete")
 	}()
 

--- a/btcd.go
+++ b/btcd.go
@@ -154,7 +154,7 @@ func pktdMain(serverChan chan<- *server) er.R {
 		return err
 	}
 	defer func() {
-		// Shut down in21 minutes, or just pull the plug.
+		// Shut down in 2 minutes, or just pull the plug.
 		const shutdownTimeout = 2 * time.Minute
 		pktdLog.Infof("Attempting graceful shutdown (%s timeout)...", shutdownTimeout)
 		server.Stop()


### PR DESCRIPTION
﻿then shutdown .... *less gracefully.* 

Using our `GoLevelDB` fork, (and *probably* the latest upstream `GoLevelDB` too), panic is hooked so a graceful shutdown for at least the database is still attempted to avoid corruption.


Demonstration:
```
1604377240 [INF] BTCD signal.go:35: Received signal (terminated).  Shutting down...
1604377240 [INF] BTCD btcd.go:159: Attempting graceful shutdown (1m0s timeout)...
1604377240 [WRN] SRVR server.go:2372: Server shutting down
1604377240 [WRN] RPCS rpcserver.go:4016: RPC server shutting down
1604377240 [INF] RPCS rpcserver.go:4028: RPC server shutdown complete
1604377240 [INF] SYNC manager.go:1534: Sync manager shutting down
1604377240 [INF] AMGR addrmanager.go:595: Address manager shutting down
1604377300 [ERR] BTCD btcd.go:170: Graceful shutdown in 1m0s failed - forcefully terminating in 5s...
1604377305 [INF] BTCD btcd.go:109: Gracefully shutting down the database...
panic: Forcefully terminating the server process...

goroutine 1 [running]:
main.pktdMain.func3(0xc000380f00)
	btcd.go:173 +0x24b
main.pktdMain(0x0, 0x0, 0x0)
	btcd.go:188 +0x97a
main.main()
	btcd.go:345 +0x13f
```