### PR TITLE
Allow empty addr message to normalize with Satoshi

### DIFF
--- a/server.go
+++ b/server.go
@@ -1246,12 +1246,10 @@ func (sp *serverPeer) OnAddr(_ *peer.Peer, msg *wire.MsgAddr) {
 		return
 	}
 
-	// A message that has no addresses is invalid.
+	// A message that has no addresses produces a warning.
 	if len(msg.AddrList) == 0 {
-		peerLog.Errorf("Command [%s] from %s does not contain any addresses",
+		peerLog.Warnf("Command [%s] from %s does not contain any addresses",
 			msg.Command(), sp.Peer)
-		sp.Disconnect()
-		return
 	}
 
 	for _, na := range msg.AddrList {


### PR DESCRIPTION


﻿See the Bitcoin Protocol documentation:
https://en.bitcoin.it/wiki/Protocol_documentation#Message_types

To normalize to Bitcoin Core, messages without
addresses are no longer invalid, so just warn
about them and continue on with life.
