### PR TITLE
Normalize with Satoshi: Warn on extra verack msgs.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1467,9 +1467,7 @@ out:
 			// No read lock is necessary because verAckReceived is not written
 			// to in any other goroutine.
 			if p.verAckReceived {
-				log.Infof("Already received 'verack' from peer %v -- "+
-					"disconnecting", p)
-				break out
+				log.Infof("Received extraneous 'verack' message from peer %v", p)
 			}
 			p.flagsMtx.Lock()
 			p.verAckReceived = true


### PR DESCRIPTION


﻿Don't disconnect a peer that sends more than one
'verack' message, just log and warn about it,
because it's weird, and shouldn't be happenning.

The Bitcoin Core client sends a reject message,
but we won't, because, per the Satoshi client,
"reject messages are now deprecated" and "have
no use case on the P2P network ... Furthermore,
they increase bandwidth and can be harmful for
privacy and security ... BIP 61 reject messages
will be disabled by default in a future version,
and then will be removed entirely."

See: https://bitcoin.org/en/release/v0.18.0#deprecated-p2p-messages
