### PR TITLE
connmgr/connmanager_test: New test: TestConnReqString

### DIFF
--- a/connmgr/connmanager_test.go
+++ b/connmgr/connmanager_test.go
@@ -664,3 +664,23 @@ out:
 	cmgr.Stop()
 	cmgr.Wait()
 }
+
+// TestConnReqString ensures that ConnReq.String() does not crash
+func TestConnReqString(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ConnReq.String crashed %v", r)
+		}
+	}()
+	cr1 := &ConnReq{
+		Addr: &net.TCPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: 18555,
+		},
+		Permanent: true,
+	}
+	_ = cr1.String()
+	cr2 := &ConnReq{}
+	_ = cr2.String()
+}
+


### PR DESCRIPTION
Ensure ConnReq.String() does not crash