### PR TITLE
peer: Default to 1s default trickle interval

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -64,7 +64,7 @@ const (
 	//
 	// XXX(trn): TODO: Implement and test using per-node and per message
 	// poisson-distributed delays, as used by Bitcoin Core, post-0.13.0.
-	DefaultTrickleInterval = 2 * time.Second
+	DefaultTrickleInterval = 1 * time.Second
 
 	// MinAcceptableProtocolVersion is the lowest protocol version that a
 	// connected peer may support.


### PR DESCRIPTION
* peer: New default to 1s default trickle interval
* Again, to be closer to Satoshi client behavior
* Add additional comments regarding trickle time