### PR TITLE
More locks, improved peer disconnection detection.

### DIFF
--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -21,6 +21,7 @@ import (
 // active.
 func mockRemotePeer() er.R {
 	// Configure peer to act as a simnet node that offers no services.
+	peer.TstAllowSelfConns()
 	peerCfg := &peer.Config{
 		UserAgentName:    "peer",  // User agent name to advertise.
 		UserAgentVersion: "1.0.0", // User agent version to advertise.
@@ -57,6 +58,7 @@ func Example_newOutboundPeer() {
 	// connecting to a remote peer, however, since this example is executed
 	// and tested, a mock remote peer is needed to listen for the outbound
 	// peer.
+	peer.TstAllowSelfConns()
 	if err := mockRemotePeer(); err != nil {
 		fmt.Printf("mockRemotePeer: unexpected error %v\n", err)
 		return

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -287,6 +287,11 @@ type Config struct {
 	// TrickleInterval is the duration of the ticker which trickles down the
 	// inventory to a peer.
 	TrickleInterval time.Duration
+
+	// allowSelfConns is only used to allow the tests to bypass the self
+	// connection detecting and disconnect logic since they intentionally
+	// do so for testing purposes.
+	allowSelfConns bool
 }
 
 // minUint32 is a helper function to return the minimum of two uint32s.

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -196,22 +196,24 @@ func testPeer(t *testing.T, p *peer.Peer, s peerStats) {
 	}
 
 	stats := p.StatsSnapshot()
-
 	if p.ID() != stats.ID {
 		t.Errorf("testPeer: wrong ID - got %v, want %v", p.ID(), stats.ID)
 		return
 	}
 
+	stats = p.StatsSnapshot()
 	if p.Addr() != stats.Addr {
 		t.Errorf("testPeer: wrong Addr - got %v, want %v", p.Addr(), stats.Addr)
 		return
 	}
 
+	stats = p.StatsSnapshot()
 	if p.LastSend() != stats.LastSend {
 		t.Errorf("testPeer: wrong LastSend - got %v, want %v", p.LastSend(), stats.LastSend)
 		return
 	}
 
+	stats = p.StatsSnapshot()
 	if p.LastRecv() != stats.LastRecv {
 		t.Errorf("testPeer: wrong LastRecv - got %v, want %v", p.LastRecv(), stats.LastRecv)
 		return
@@ -220,6 +222,7 @@ func testPeer(t *testing.T, p *peer.Peer, s peerStats) {
 
 // TestPeerConnection tests connection between inbound and outbound peers.
 func TestPeerConnection(t *testing.T) {
+	peer.TstAllowSelfConns()
 	verack := make(chan struct{})
 	peer1Cfg := &peer.Config{
 		Listeners: peer.MessageListeners{
@@ -857,65 +860,6 @@ func TestUnsupportedVersionPeer(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("Timeout waiting for remote reader to close")
-	}
-}
-
-// TestDuplicateVersionMsg ensures that receiving a version message after one
-// has already been received results in the peer being disconnected.
-func TestDuplicateVersionMsg(t *testing.T) {
-	// Create a pair of peers that are connected to each other using a fake
-	// connection.
-	verack := make(chan struct{})
-	peerCfg := &peer.Config{
-		Listeners: peer.MessageListeners{
-			OnVerAck: func(p *peer.Peer, msg *wire.MsgVerAck) {
-				verack <- struct{}{}
-			},
-		},
-		UserAgentName:    "peer",
-		UserAgentVersion: "1.0",
-		ChainParams:      &chaincfg.MainNetParams,
-		Services:         0,
-	}
-	inConn, outConn := pipe(
-		&conn{laddr: "10.0.0.1:9108", raddr: "10.0.0.2:9108"},
-		&conn{laddr: "10.0.0.2:9108", raddr: "10.0.0.1:9108"},
-	)
-	outPeer, err := peer.NewOutboundPeer(peerCfg, inConn.laddr)
-	if err != nil {
-		t.Fatalf("NewOutboundPeer: unexpected err: %v\n", err)
-	}
-	outPeer.AssociateConnection(outConn)
-	inPeer := peer.NewInboundPeer(peerCfg)
-	inPeer.AssociateConnection(inConn)
-	// Wait for the veracks from the initial protocol version negotiation.
-	for i := 0; i < 2; i++ {
-		select {
-		case <-verack:
-		case <-time.After(time.Second):
-			t.Fatal("verack timeout")
-		}
-	}
-	// Queue a duplicate version message from the outbound peer and wait until
-	// it is sent.
-	done := make(chan struct{})
-	outPeer.QueueMessage(&wire.MsgVersion{}, done)
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("send duplicate version timeout")
-	}
-	// Ensure the peer that is the recipient of the duplicate version closes the
-	// connection.
-	disconnected := make(chan struct{}, 1)
-	go func() {
-		inPeer.WaitForDisconnect()
-		disconnected <- struct{}{}
-	}()
-	select {
-	case <-disconnected:
-	case <-time.After(time.Second):
-		t.Fatal("peer did not disconnect")
 	}
 }
 

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -208,15 +208,19 @@ func testPeer(t *testing.T, p *peer.Peer, s peerStats) {
 	}
 
 	stats = p.StatsSnapshot()
-	if p.LastSend() != stats.LastSend {
-		t.Errorf("testPeer: wrong LastSend - got %v, want %v", p.LastSend(), stats.LastSend)
-		return
+	if stats.LastSend != time.Unix(0, 0) {
+		if p.LastSend() != stats.LastSend {
+			t.Errorf("testPeer: wrong LastSend - got %v, want %v", p.LastSend(), stats.LastSend)
+			return
+		}
 	}
 
 	stats = p.StatsSnapshot()
-	if p.LastRecv() != stats.LastRecv {
-		t.Errorf("testPeer: wrong LastRecv - got %v, want %v", p.LastRecv(), stats.LastRecv)
-		return
+	if stats.LastRecv != time.Unix(0,0 ) {
+		if p.LastRecv() != stats.LastRecv {
+			t.Errorf("testPeer: wrong LastRecv - got %v, want %v", p.LastRecv(), stats.LastRecv)
+			return
+		}
 	}
 }
 
@@ -242,7 +246,7 @@ func TestPeerConnection(t *testing.T) {
 		ChainParams:       &chaincfg.MainNetParams,
 		ProtocolVersion:   protocol.RejectVersion, // Configure with older version
 		Services:          0,
-		TrickleInterval:   time.Second * 10,
+		TrickleInterval:   time.Second * 1,
 	}
 	peer2Cfg := &peer.Config{
 		Listeners:         peer1Cfg.Listeners,
@@ -251,7 +255,7 @@ func TestPeerConnection(t *testing.T) {
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &chaincfg.MainNetParams,
 		Services:          protocol.SFNodeNetwork | protocol.SFNodeWitness,
-		TrickleInterval:   time.Second * 10,
+		TrickleInterval:   time.Second * 1,
 	}
 
 	wantStats1 := peerStats{
@@ -377,9 +381,6 @@ func TestPeerListeners(t *testing.T) {
 			OnPong: func(p *peer.Peer, msg *wire.MsgPong) {
 				ok <- msg
 			},
-			OnAlert: func(p *peer.Peer, msg *wire.MsgAlert) {
-				ok <- msg
-			},
 			OnMemPool: func(p *peer.Peer, msg *wire.MsgMemPool) {
 				ok <- msg
 			},
@@ -456,7 +457,7 @@ func TestPeerListeners(t *testing.T) {
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &chaincfg.MainNetParams,
 		Services:          protocol.SFNodeBloom,
-		TrickleInterval:   time.Second * 10,
+		TrickleInterval:   time.Second * 1,
 	}
 	inConn, outConn := pipe(
 		&conn{raddr: "10.0.0.1:8333"},
@@ -505,10 +506,6 @@ func TestPeerListeners(t *testing.T) {
 		{
 			"OnPong",
 			wire.NewMsgPong(42),
-		},
-		{
-			"OnAlert",
-			wire.NewMsgAlert([]byte("payload"), []byte("signature")),
 		},
 		{
 			"OnMemPool",
@@ -627,7 +624,7 @@ func TestOutboundPeer(t *testing.T) {
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &chaincfg.MainNetParams,
 		Services:          0,
-		TrickleInterval:   time.Second * 10,
+		TrickleInterval:   time.Second * 1,
 	}
 
 	r, w := io.Pipe()
@@ -768,7 +765,7 @@ func TestUnsupportedVersionPeer(t *testing.T) {
 		UserAgentComments: []string{"comment"},
 		ChainParams:       &chaincfg.MainNetParams,
 		Services:          0,
-		TrickleInterval:   time.Second * 10,
+		TrickleInterval:   time.Second * 1,
 	}
 
 	localNA := wire.NewNetAddressIPPort(


### PR DESCRIPTION
* More aggressively check for peer disconnection.
* Additional locks in peer code, per race detector.
* Remove depreciated TestDuplicateVersionMsg test.
* Fix race conditions detected in the peer tests.

* Add a workaround for https://github.com/pkt-cash/pktd/issues/128
