### PR TITLE
Fix cookie authentication; always show version information

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,7 +30,6 @@ import (
 	_ "github.com/pkt-cash/pktd/database/ffldb"
 	"github.com/pkt-cash/pktd/mempool"
 	"github.com/pkt-cash/pktd/peer"
-	"github.com/pkt-cash/pktd/pktconfig/version"
 )
 
 const (
@@ -448,12 +447,11 @@ func loadConfig() (*config, []string, er.R) {
 		}
 	}
 
-	// Show the version and exit if the version flag was specified.
+	// Just need to exit if the version flag was specified
 	appName := filepath.Base(os.Args[0])
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	usageMessage := fmt.Sprintf("Use %s -h to show usage", appName)
 	if preCfg.ShowVersion {
-		fmt.Println(appName, "version", version.Version())
 		os.Exit(0)
 	}
 
@@ -740,8 +738,8 @@ func loadConfig() (*config, []string, er.R) {
 	}
 
 	if cfg.RPCUser == "" || cfg.RPCPass == "" {
-		pktdLog.Infof("Creating a .cookie file")
-		cookiePath := filepath.Join(defaultHomeDir, ".cookie")
+		pktdLog.Infof("Creating a new .pktcookie authorization file")
+		cookiePath := filepath.Join(defaultHomeDir, ".pktcookie")
 		var buf [32]byte
 		if _, errr := rand.Read(buf[:]); errr != nil {
 			err := er.E(errr)
@@ -753,7 +751,7 @@ func loadConfig() (*config, []string, er.R) {
 		cookie := cfg.RPCUser + ":" + cfg.RPCPass
 		if errr := ioutil.WriteFile(cookiePath, []byte(cookie), 0600); errr != nil {
 			err := er.E(errr)
-			err.AddMessage("Could not write cookie")
+			err.AddMessage("Could not write .pktcookie file")
 			return nil, nil, err
 		}
 	}

--- a/pktconfig/util.go
+++ b/pktconfig/util.go
@@ -85,8 +85,8 @@ func ReadUserPass(filePath string) ([]string, er.R) {
 		return nil, er.E(errr)
 	}
 	// Couldn't find the file or didn't have user/pass
-	// Lets see if there's a .cookie file
-	cookiePath := strings.ReplaceAll(filePath, "pktd.conf", ".cookie")
+	// Lets see if there's a cookie file
+	cookiePath := strings.ReplaceAll(filePath, "pktd.conf", ".pktcookie")
 	if cookiePath == filePath {
 		return nil, nil
 	} else if cookie, errr := ioutil.ReadFile(cookiePath); errr != nil {

--- a/pktd.go
+++ b/pktd.go
@@ -45,6 +45,10 @@ var winServiceMain func() (bool, er.R)
 // notified with the server once it is setup so it can gracefully stop it when
 // requested from the service control manager.
 func pktdMain(serverChan chan<- *server) er.R {
+
+	// Unconditionally show the version informatin at startup.
+	pktdLog.Infof("Version %s", version.Version())
+
 	// Load configuration and parse command line.  This function also
 	// initializes logging and configures it accordingly.
 	tcfg, _, err := loadConfig()
@@ -53,16 +57,18 @@ func pktdMain(serverChan chan<- *server) er.R {
 	}
 	cfg = tcfg
 
+	// Warn if running a pre-released pktd
+	version.WarnIfPrerelease(pktdLog)
+
 	// Get a channel that will be closed when a shutdown signal has been
 	// triggered either from an OS signal such as SIGINT (Ctrl+C) or from
 	// another subsystem such as the RPC server.
 	interrupt := interruptListener()
 	defer pktdLog.Info("Shutdown complete")
 
-	// Show version at startup.
-	pktdLog.Infof("Version %s", version.Version())
-
-	version.WarnIfPrerelease(pktdLog)
+	
+	
+	
 
 	// Enable http profiling server if requested.
 	if cfg.Profile != "" {

--- a/rpcclient/cookiefile.go
+++ b/rpcclient/cookiefile.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2017 The Namecoin developers
+// Copyright (c) 2019 The btcsuite developers
+// Copyright (c) 2020 Jeffrey H. Johnson
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package rpcclient
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/pkt-cash/pktd/btcutil/er"
+)
+
+func readCookieFile(path string) (username, password string, err er.R) {
+	f, errr := os.Open(path)
+	if errr != nil {
+		return
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Scan()
+	errr = scanner.Err()
+	if errr != nil {
+		return
+	}
+	s := scanner.Text()
+
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		err := er.E(errr)
+		err.AddMessage("Corrupt or malformed pktcookie file")
+		return "", "", err
+	}
+
+	username, password = parts[0], parts[1]
+	return
+}


### PR DESCRIPTION
 * Use .pktcookie for the cookie file name
 * Better log output, mention authorization, etc
 * Make rpcclient actually use the cookie data
 * Try user specified user/pass before the cookie
 * Implement cookie data authentication cache
 * Unconditionally output pktd version information
