### PR TITLE
Neutrino Improvements, mainly upstream backports

### DIFF
--- a/neutrino/blockmanager.go
+++ b/neutrino/blockmanager.go
@@ -1269,9 +1269,13 @@ func (b *blockManager) resolveConflict(
 					log.Errorf("Unable to ban peer %v: %v",
 						peer, err)
 				}
+				if sp := b.server.PeerByAddr(peer); sp != nil {
+					sp.Disconnect()
+				}
 				delete(checkpoints, peer)
 				break
-			} else if err != nil {
+			}
+			if err != nil {
 				return nil, err
 			}
 		}

--- a/neutrino/neutrino.go
+++ b/neutrino/neutrino.go
@@ -234,9 +234,7 @@ func (sp *ServerPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 			log.Errorf("Unable to ban peer %v: %v", peerAddr, err)
 		}
 
-		if sp.connReq != nil {
-			sp.server.connManager.Remove(sp.connReq.ID())
-		}
+		sp.Disconnect()
 
 		return nil
 	}
@@ -1285,22 +1283,20 @@ func (s *ChainService) handleDonePeerMsg(state *peerState, sp *ServerPeer) {
 			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
 		}
 		if !sp.Inbound() && sp.connReq != nil {
-			s.connManager.Disconnect(sp.connReq.ID())
+			if sp.persistent {
+				s.connManager.Disconnect(sp.connReq.ID())
+			} else {
+				s.connManager.Remove(sp.connReq.ID())
+			}
 		}
 		delete(list, sp.ID())
 		log.Debugf("Removed peer %s", sp)
 		return
 	}
 
+	// We'll always remove peers that are not persistent.
 	if sp.connReq != nil {
-		// If the peer has been banned, we'll remove the connection
-		// request from the manager to ensure we don't reconnect again.
-		// Otherwise, we'll just simply disconnect.
-		if s.IsBanned(sp.connReq.Addr.String()) {
-			s.connManager.Remove(sp.connReq.ID())
-		} else {
-			s.connManager.Disconnect(sp.connReq.ID())
-		}
+		s.connManager.Remove(sp.connReq.ID())
 	}
 
 	// Update the address' last seen time if the peer has acknowledged
@@ -1386,18 +1382,31 @@ func newPeerConfig(sp *ServerPeer) *peer.Config {
 // request instance and the connection itself, and finally notifies the address
 // manager of the attempt.
 func (s *ChainService) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
+	// In the event that we have to disconnect the peer, we'll choose the
+	// appropriate method to do so based on whether the connection request
+	// is for a persistent peer or not.
+	var disconnect func()
+	if c.Permanent {
+		disconnect = func() {
+			s.connManager.Disconnect(c.ID())
+		}
+	} else {
+		disconnect = func() {
+			s.connManager.Remove(c.ID())
+		}
+	}
+
 	// If the peer is banned, then we'll disconnect them.
 	peerAddr := c.Addr.String()
 	if s.IsBanned(peerAddr) {
-		// Remove will end up closing the connection.
-		s.connManager.Remove(c.ID())
+		disconnect()
 		return
 	}
 
 	// If we're already connected to this peer, then we'll close out the new
 	// connection and keep the old.
 	if s.PeerByAddr(peerAddr) != nil {
-		conn.Close()
+		disconnect()
 		return
 	}
 
@@ -1405,7 +1414,8 @@ func (s *ChainService) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) 
 	p, err := peer.NewOutboundPeer(newPeerConfig(sp), peerAddr)
 	if err != nil {
 		log.Debugf("Cannot create outbound peer %s: %s", c.Addr, err)
-		s.connManager.Disconnect(c.ID())
+		disconnect()
+		return
 	}
 	sp.Peer = p
 	sp.connReq = c

--- a/neutrino/neutrino.go
+++ b/neutrino/neutrino.go
@@ -40,7 +40,7 @@ var (
 	// ConnectionRetryInterval is the base amount of time to wait in
 	// between retries when connecting to persistent peers.  It is adjusted
 	// by the number of retries such that there is a retry backoff.
-	ConnectionRetryInterval = time.Second * 5
+	ConnectionRetryInterval = time.Second * 3
 
 	// UserAgentName is the user agent name and is used to help identify
 	// ourselves to other bitcoin peers.
@@ -754,7 +754,7 @@ func NewChainService(cfg Config) (*ChainService, er.R) {
 			for tries := 0; tries < 100; tries++ {
 				select {
 				case <-s.quit:
-					return nil, ErrShuttingDown
+					return nil, er.Errorf("Neutrino already shutting down...")
 				default:
 				}
 
@@ -773,6 +773,7 @@ func NewChainService(cfg Config) (*ChainService, er.R) {
 				// Skip any addresses that correspond to our set
 				// of currently connected peers.
 				if _, ok := connectedPeers[addrString]; ok {
+					log.Debugf("Skipping new connection from already connected peer %v", addrString)
 					continue
 				}
 
@@ -878,11 +879,10 @@ func NewChainService(cfg Config) (*ChainService, er.R) {
 			// peer.
 			var tcpAddr net.Addr
 			for {
-				var err error
 				tcpAddr, err = s.addrStringToNetAddr(addr)
 				if err != nil {
 					log.Warnf("unable to lookup IP for "+
-						"%v: %v", addr, err)
+						"%v", addr)
 
 					select {
 					// Try again in 5 seconds.

--- a/neutrino/neutrino.go
+++ b/neutrino/neutrino.go
@@ -832,23 +832,6 @@ func NewChainService(cfg Config) (*ChainService, er.R) {
 	}
 	s.connManager = cmgr
 
-	// Start up persistent peers.
-	permanentPeers := cfg.ConnectPeers
-	if len(permanentPeers) == 0 {
-		permanentPeers = cfg.AddPeers
-	}
-	for _, addr := range permanentPeers {
-		tcpAddr, err := s.addrStringToNetAddr(addr)
-		if err != nil {
-			return nil, err
-		}
-
-		go s.connManager.Connect(&connmgr.ConnReq{
-			Addr:      tcpAddr,
-			Permanent: true,
-		})
-	}
-
 	s.utxoScanner = NewUtxoScanner(&UtxoScannerConfig{
 		BestSnapshot: s.BestBlock,
 		GetBlockHash: s.GetBlockHash,
@@ -875,6 +858,49 @@ func NewChainService(cfg Config) (*ChainService, er.R) {
 	s.banStore, err = banman.NewStore(cfg.Database)
 	if err != nil {
 		return nil, er.Errorf("unable to initialize ban store: %v", err)
+	}
+
+	// Start up persistent peers.
+	permanentPeers := cfg.ConnectPeers
+	if len(permanentPeers) == 0 {
+		permanentPeers = cfg.AddPeers
+	}
+
+	for _, addr := range permanentPeers {
+		addr := addr
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+
+			// Since netwok access might not be established yet, we
+			// loop until we are able to look up the permanent
+			// peer.
+			var tcpAddr net.Addr
+			for {
+				var err error
+				tcpAddr, err = s.addrStringToNetAddr(addr)
+				if err != nil {
+					log.Warnf("unable to lookup IP for "+
+						"%v: %v", addr, err)
+
+					select {
+					// Try again in 5 seconds.
+					case <-time.After(ConnectionRetryInterval):
+					case <-s.quit:
+						return
+					}
+					continue
+				}
+
+				break
+			}
+
+			s.connManager.Connect(&connmgr.ConnReq{
+				Addr:      tcpAddr,
+				Permanent: true,
+			})
+		}()
 	}
 
 	return &s, nil


### PR DESCRIPTION


- blockmanager: update chain tip before notification
- blockmanager: disconnect banned peer upon invalid filter header check…
- neutrino: standardize use of connmgr.Remove and connmgr.Disconnect
- neutrino: mark address as connected within handleAddPeerMsg
- hainservice: retry lookup IP on startup
- Neutrino: Faster reconnects, better debug messages
