### PR TITLE
Do not run the test suite in parallel by default

### DIFF
--- a/addrmgr/addrmanager_internal_test.go
+++ b/addrmgr/addrmanager_internal_test.go
@@ -92,7 +92,6 @@ func assertAddrs(t *testing.T, addrMgr *AddrManager,
 // TestAddrManagerSerialization ensures that we can properly serialize and
 // deserialize the manager's current address cache.
 func TestAddrManagerSerialization(t *testing.T) {
-	t.Parallel()
 
 	// We'll start by creating our address manager backed by a temporary
 	// directory.
@@ -132,7 +131,6 @@ func TestAddrManagerSerialization(t *testing.T) {
 // TestAddrManagerV1ToV2 ensures that we can properly upgrade the serialized
 // version of the address manager from v1 to v2.
 func TestAddrManagerV1ToV2(t *testing.T) {
-	t.Parallel()
 
 	// We'll start by creating our address manager backed by a temporary
 	// directory.

--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -19,7 +19,6 @@ import (
 // TestStxoSerialization ensures serializing and deserializing spent transaction
 // output entries works as expected.
 func TestStxoSerialization(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name       string
@@ -113,7 +112,6 @@ func TestStxoSerialization(t *testing.T) {
 // TestStxoDecodeErrors performs negative tests against decoding spent
 // transaction outputs to ensure error paths work as expected.
 func TestStxoDecodeErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name       string
@@ -183,7 +181,6 @@ func TestStxoDecodeErrors(t *testing.T) {
 // TestSpendJournalSerialization ensures serializing and deserializing spend
 // journal entries works as expected.
 func TestSpendJournalSerialization(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name       string
@@ -316,7 +313,6 @@ func TestSpendJournalSerialization(t *testing.T) {
 // TestSpendJournalErrors performs negative tests against deserializing spend
 // journal entries to ensure error paths work as expected.
 func TestSpendJournalErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name       string
@@ -384,7 +380,6 @@ func TestSpendJournalErrors(t *testing.T) {
 // TestUtxoSerialization ensures serializing and deserializing unspent
 // trasaction output entries works as expected.
 func TestUtxoSerialization(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name       string
@@ -511,7 +506,6 @@ func TestUtxoSerialization(t *testing.T) {
 // TestUtxoEntryHeaderCodeErrors performs negative tests against unspent
 // transaction output header codes to ensure error paths work as expected.
 func TestUtxoEntryHeaderCodeErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name    string
@@ -546,7 +540,6 @@ func TestUtxoEntryHeaderCodeErrors(t *testing.T) {
 // TestUtxoEntryDeserializeErrors performs negative tests against deserializing
 // unspent transaction outputs to ensure error paths work as expected.
 func TestUtxoEntryDeserializeErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name       string
@@ -586,7 +579,6 @@ func TestUtxoEntryDeserializeErrors(t *testing.T) {
 // TestBestChainStateSerialization ensures serializing and deserializing the
 // best chain state works as expected.
 func TestBestChainStateSerialization(t *testing.T) {
-	t.Parallel()
 
 	workSum := new(big.Int)
 	tests := []struct {
@@ -653,7 +645,6 @@ func TestBestChainStateSerialization(t *testing.T) {
 // TestBestChainStateDeserializeErrors performs negative tests against
 // deserializing the chain state to ensure error paths work as expected.
 func TestBestChainStateDeserializeErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name       string

--- a/blockchain/compress_test.go
+++ b/blockchain/compress_test.go
@@ -25,7 +25,6 @@ func hexToBytes(s string) []byte {
 // TestVLQ ensures the variable length quantity serialization, deserialization,
 // and size calculation works as expected.
 func TestVLQ(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		val        uint64
@@ -105,7 +104,6 @@ func TestVLQ(t *testing.T) {
 // TestScriptCompression ensures the domain-specific script compression and
 // decompression works as expected.
 func TestScriptCompression(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name         string
@@ -229,7 +227,6 @@ func TestScriptCompression(t *testing.T) {
 // TestScriptCompressionErrors ensures calling various functions related to
 // script compression with incorrect data returns the expected results.
 func TestScriptCompressionErrors(t *testing.T) {
-	t.Parallel()
 
 	// A nil script must result in a decoded size of 0.
 	if gotSize := decodeCompressedScriptSize(nil); gotSize != 0 {
@@ -257,7 +254,6 @@ func TestScriptCompressionErrors(t *testing.T) {
 // TestAmountCompression ensures the domain-specific transaction output amount
 // compression and decompression works as expected.
 func TestAmountCompression(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name         string
@@ -335,7 +331,6 @@ func TestAmountCompression(t *testing.T) {
 // TestCompressedTxOut ensures the transaction output serialization and
 // deserialization works as expected.
 func TestCompressedTxOut(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name       string
@@ -425,7 +420,6 @@ func TestCompressedTxOut(t *testing.T) {
 // TestTxOutCompressionErrors ensures calling various functions related to
 // txout compression with incorrect data returns the expected results.
 func TestTxOutCompressionErrors(t *testing.T) {
-	t.Parallel()
 
 	// A compressed txout with missing compressed script must error.
 	compressedTxOut := hexToBytes("00")

--- a/blockchain/indexers/addrindex_test.go
+++ b/blockchain/indexers/addrindex_test.go
@@ -169,7 +169,6 @@ func (b *addrIndexBucket) sanityCheck(addrKey [addrKeySize]byte, expectedTotal i
 // index creates multiple levels as described by the address index
 // documentation.
 func TestAddrIndexLevels(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name        string

--- a/blockchain/thresholdstate_test.go
+++ b/blockchain/thresholdstate_test.go
@@ -13,7 +13,6 @@ import (
 // TestThresholdStateStringer tests the stringized output for the
 // ThresholdState type.
 func TestThresholdStateStringer(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		in   ThresholdState
@@ -47,7 +46,6 @@ func TestThresholdStateStringer(t *testing.T) {
 // TestThresholdStateCache ensure the threshold state cache works as intended
 // including adding entries, updating existing entries, and flushing.
 func TestThresholdStateCache(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name       string

--- a/btcjson/btcdextcmds_test.go
+++ b/btcjson/btcdextcmds_test.go
@@ -21,7 +21,6 @@ import (
 // marshalled command, while optional fields with defaults have the default
 // assigned on unmarshalled commands.
 func TestBtcdExtCmds(t *testing.T) {
-	t.Parallel()
 
 	testID := int(1)
 	tests := []struct {

--- a/btcjson/btcdextresults_test.go
+++ b/btcjson/btcdextresults_test.go
@@ -16,7 +16,6 @@ import (
 // work as inteded.
 // and unmarshal code of results are as expected.
 func TestBtcdExtCustomResults(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -6,7 +6,6 @@ package btcjson_test
 
 import (
 	"bytes"
-	/*"encoding/json" XXX -trn */
 	"github.com/json-iterator/go"
 	"fmt"
 	"reflect"
@@ -22,7 +21,6 @@ import (
 // marshalled command, while optional fields with defaults have the default
 // assigned on unmarshalled commands.
 func TestChainSvrCmds(t *testing.T) {
-	t.Parallel()
 
 	testID := int(1)
 	tests := []struct {
@@ -1164,7 +1162,6 @@ func TestChainSvrCmds(t *testing.T) {
 // TestChainSvrCmdErrors ensures any errors that occur in the command during
 // custom mashal and unmarshal are as expected.
 /*func TestChainSvrCmdErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name       string

--- a/btcjson/chainsvrresults_test.go
+++ b/btcjson/chainsvrresults_test.go
@@ -15,7 +15,6 @@ import (
 // work as inteded.
 // and unmarshal code of results are as expected.
 func TestChainSvrCustomResults(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string

--- a/btcjson/chainsvrwscmds_test.go
+++ b/btcjson/chainsvrwscmds_test.go
@@ -22,7 +22,6 @@ import (
 // being omitted in the marshalled command, while optional fields with defaults
 // have the default assigned on unmarshalled commands.
 func TestChainSvrWsCmds(t *testing.T) {
-	t.Parallel()
 
 	testID := int(1)
 	tests := []struct {

--- a/btcjson/chainsvrwsntfns_test.go
+++ b/btcjson/chainsvrwsntfns_test.go
@@ -22,7 +22,6 @@ import (
 // optional fields being omitted in the marshalled command, while optional
 // fields with defaults have the default assigned on unmarshalled commands.
 func TestChainSvrWsNtfns(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name         string

--- a/btcjson/chainsvrwsresults_test.go
+++ b/btcjson/chainsvrwsresults_test.go
@@ -15,7 +15,6 @@ import (
 // TestChainSvrWsResults ensures any results that have custom marshalling
 // work as inteded.
 func TestChainSvrWsResults(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string

--- a/btcjson/cmdinfo_test.go
+++ b/btcjson/cmdinfo_test.go
@@ -15,7 +15,6 @@ import (
 // TestCmdMethod tests the CmdMethod function to ensure it retunrs the expected
 // methods and errors.
 func TestCmdMethod(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name   string
@@ -61,7 +60,6 @@ func TestCmdMethod(t *testing.T) {
 // TestMethodUsageFlags tests the MethodUsage function ensure it returns the
 // expected flags and errors.
 func TestMethodUsageFlags(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name   string
@@ -107,7 +105,6 @@ func TestMethodUsageFlags(t *testing.T) {
 // TestMethodUsageText tests the MethodUsageText function ensure it returns the
 // expected text.
 func TestMethodUsageText(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string
@@ -172,7 +169,6 @@ func TestMethodUsageText(t *testing.T) {
 // TestFieldUsage tests the internal fieldUsage function ensure it returns the
 // expected text.
 func TestFieldUsage(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string

--- a/btcjson/cmdparse_test.go
+++ b/btcjson/cmdparse_test.go
@@ -19,7 +19,6 @@ import (
 // TestAssignField tests the assignField function handles supported combinations
 // properly.
 func TestAssignField(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string
@@ -194,7 +193,6 @@ func TestAssignField(t *testing.T) {
 
 // TestAssignFieldErrors tests the assignField function error paths.
 func TestAssignFieldErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name string
@@ -345,7 +343,6 @@ func TestAssignFieldErrors(t *testing.T) {
 
 // TestNewCmdErrors ensures the error paths of NewCmd behave as expected.
 func TestNewCmdErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name   string
@@ -392,7 +389,6 @@ func TestNewCmdErrors(t *testing.T) {
 
 // TestMarshalCmdErrors  tests the error paths of the MarshalCmd function.
 func TestMarshalCmdErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name string
@@ -433,7 +429,6 @@ func TestMarshalCmdErrors(t *testing.T) {
 
 // TestUnmarshalCmdErrors  tests the error paths of the UnmarshalCmd function.
 func TestUnmarshalCmdErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name    string

--- a/btcjson/help_test.go
+++ b/btcjson/help_test.go
@@ -16,7 +16,6 @@ import (
 // TestHelpReflectInternals ensures the various help functions which deal with
 // reflect types work as expected for various Go types.
 func TestHelpReflectInternals(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name        string
@@ -293,7 +292,6 @@ func TestHelpReflectInternals(t *testing.T) {
 // TestResultStructHelp ensures the expected help text format is returned for
 // various Go struct types.
 func TestResultStructHelp(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name        string
@@ -435,7 +433,6 @@ func TestResultStructHelp(t *testing.T) {
 // TestHelpArgInternals ensures the various help functions which deal with
 // arguments work as expected for various argument types.
 func TestHelpArgInternals(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name        string
@@ -580,7 +577,6 @@ func TestHelpArgInternals(t *testing.T) {
 // TestMethodHelp ensures the method help function works as expected for various
 // command structs.
 func TestMethodHelp(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name        string
@@ -673,7 +669,6 @@ func TestMethodHelp(t *testing.T) {
 // TestGenerateHelpErrors ensures the GenerateHelp function returns the expected
 // errors.
 func TestGenerateHelpErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name        string
@@ -722,7 +717,6 @@ func TestGenerateHelpErrors(t *testing.T) {
 // as expected.  The internal are testd much more thoroughly in other tests, so
 // there is no need to add more tests here.
 func TestGenerateHelp(t *testing.T) {
-	t.Parallel()
 
 	descs := map[string]string{
 		"help--synopsis": "test",

--- a/btcjson/helpers_test.go
+++ b/btcjson/helpers_test.go
@@ -14,8 +14,6 @@ import (
 // TestHelpers tests the various helper functions which create pointers to
 // primitive types.
 func TestHelpers(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name     string
 		f        func() interface{}

--- a/btcjson/jsonrpc_test.go
+++ b/btcjson/jsonrpc_test.go
@@ -15,7 +15,6 @@ import (
 
 // TestIsValidIDType ensures the IsValidIDType function behaves as expected.
 func TestIsValidIDType(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name    string
@@ -56,8 +55,6 @@ func TestIsValidIDType(t *testing.T) {
 
 // TestMarshalResponse ensures the MarshalResponse function works as expected.
 func TestMarshalResponse(t *testing.T) {
-	t.Parallel()
-
 	testID := 1
 	tests := []struct {
 		name     string
@@ -102,7 +99,6 @@ func TestMarshalResponse(t *testing.T) {
 
 // TestMiscErrors tests a few error conditions not covered elsewhere.
 func TestMiscErrors(t *testing.T) {
-	t.Parallel()
 
 	// Force an error in NewRequest by giving it a parameter type that is
 	// not supported.
@@ -135,7 +131,6 @@ func TestMiscErrors(t *testing.T) {
 
 // TestRPCError tests the error output for the RPCError type.
 func TestRPCError(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		in   er.R

--- a/btcjson/register_test.go
+++ b/btcjson/register_test.go
@@ -16,7 +16,6 @@ import (
 
 // TestUsageFlagStringer tests the stringized output for the UsageFlag type.
 func TestUsageFlagStringer(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		in   btcjson.UsageFlag
@@ -58,7 +57,6 @@ func TestUsageFlagStringer(t *testing.T) {
 // TestRegisterCmdErrors ensures the RegisterCmd function returns the expected
 // error when provided with invalid types.
 func TestRegisterCmdErrors(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name    string
@@ -225,7 +223,6 @@ func TestRegisterCmdErrors(t *testing.T) {
 // TestMustRegisterCmdPanic ensures the MustRegisterCmd function panics when
 // used to register an invalid type.
 func TestMustRegisterCmdPanic(t *testing.T) {
-	t.Parallel()
 
 	// Setup a defer to catch the expected panic to ensure it actually
 	// paniced.
@@ -242,7 +239,6 @@ func TestMustRegisterCmdPanic(t *testing.T) {
 // TestRegisteredCmdMethods tests the RegisteredCmdMethods function ensure it
 // works as expected.
 func TestRegisteredCmdMethods(t *testing.T) {
-	t.Parallel()
 
 	// Ensure the registered methods are returned.
 	methods := btcjson.RegisteredCmdMethods()

--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -21,8 +21,6 @@ import (
 // omitted in the marshalled command, while optional fields with defaults have
 // the default assigned on unmarshalled commands.
 func TestWalletSvrCmds(t *testing.T) {
-	t.Parallel()
-
 	testID := int(1)
 	tests := []struct {
 		name         string

--- a/btcjson/walletsvrwscmds_test.go
+++ b/btcjson/walletsvrwscmds_test.go
@@ -21,7 +21,6 @@ import (
 // optional fields being omitted in the marshalled command, while optional
 // fields with defaults have the default assigned on unmarshalled commands.
 func TestWalletSvrWsCmds(t *testing.T) {
-	t.Parallel()
 
 	testID := int(1)
 	tests := []struct {

--- a/btcjson/walletsvrwsntfns_test.go
+++ b/btcjson/walletsvrwsntfns_test.go
@@ -21,7 +21,6 @@ import (
 // optional fields being omitted in the marshalled command, while optional
 // fields with defaults have the default assigned on unmarshalled commands.
 func TestWalletSvrWsNtfns(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name         string

--- a/chaincfg/params_test.go
+++ b/chaincfg/params_test.go
@@ -20,7 +20,6 @@ func TestInvalidHashStr(t *testing.T) {
 // TestMustRegisterPanic ensures the mustRegister function panics when used to
 // register an invalid network.
 func TestMustRegisterPanic(t *testing.T) {
-	t.Parallel()
 
 	// Setup a defer to catch the expected panic to ensure it actually
 	// paniced.

--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -27,7 +27,6 @@ const dbType = "ffldb"
 // TestCreateOpenFail ensures that errors related to creating and opening a
 // database are handled properly.
 func TestCreateOpenFail(t *testing.T) {
-	t.Parallel()
 
 	// Ensure that attempting to open a database that doesn't exist returns
 	// the expected error.
@@ -153,7 +152,6 @@ func TestCreateOpenFail(t *testing.T) {
 // TestPersistence ensures that values stored are still valid after closing and
 // reopening the database.
 func TestPersistence(t *testing.T) {
-	t.Parallel()
 
 	// Create a new database to run tests against.
 	dbPath := filepath.Join(os.TempDir(), "ffldb-persistencetest")
@@ -259,7 +257,6 @@ func TestPersistence(t *testing.T) {
 
 // TestInterface performs all interfaces tests for this database driver.
 func TestInterface(t *testing.T) {
-	t.Parallel()
 
 	// Create a new database to run tests against.
 	dbPath := filepath.Join(os.TempDir(), "ffldb-interfacetest")

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -125,7 +125,6 @@ type testContext struct {
 // TestConvertErr ensures the leveldb error to database error conversion works
 // as expected.
 func TestConvertErr(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		err         error
@@ -150,7 +149,6 @@ func TestConvertErr(t *testing.T) {
 // TestCornerCases ensures several corner cases which can happen when opening
 // a database and/or block files work as expected.
 func TestCornerCases(t *testing.T) {
-	t.Parallel()
 
 	// Create a file at the datapase path to force the open below to fail.
 	dbPath := filepath.Join(os.TempDir(), "ffldb-errors")

--- a/database/internal/treap/common_test.go
+++ b/database/internal/treap/common_test.go
@@ -20,7 +20,6 @@ func serializeUint32(ui uint32) []byte {
 
 // TestParentStack ensures the treapParentStack functionality works as intended.
 func TestParentStack(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		numNodes int

--- a/database/internal/treap/immutable_test.go
+++ b/database/internal/treap/immutable_test.go
@@ -13,7 +13,6 @@ import (
 // TestImmutableEmpty ensures calling functions on an empty immutable treap
 // works as expected.
 func TestImmutableEmpty(t *testing.T) {
-	t.Parallel()
 
 	// Ensure the treap length is the expected value.
 	testTreap := NewImmutable()
@@ -55,7 +54,6 @@ func TestImmutableEmpty(t *testing.T) {
 // TestImmutableSequential ensures that putting keys into an immutable treap in
 // sequential order works as expected.
 func TestImmutableSequential(t *testing.T) {
-	t.Parallel()
 
 	// Insert a bunch of sequential keys while checking several of the treap
 	// functions work as expected.
@@ -155,7 +153,6 @@ func TestImmutableSequential(t *testing.T) {
 // TestImmutableReverseSequential ensures that putting keys into an immutable
 // treap in reverse sequential order works as expected.
 func TestImmutableReverseSequential(t *testing.T) {
-	t.Parallel()
 
 	// Insert a bunch of sequential keys while checking several of the treap
 	// functions work as expected.
@@ -256,7 +253,6 @@ func TestImmutableReverseSequential(t *testing.T) {
 // TestImmutableUnordered ensures that putting keys into an immutable treap in
 // no paritcular order works as expected.
 func TestImmutableUnordered(t *testing.T) {
-	t.Parallel()
 
 	// Insert a bunch of out-of-order keys while checking several of the
 	// treap functions work as expected.
@@ -333,7 +329,6 @@ func TestImmutableUnordered(t *testing.T) {
 // TestImmutableDuplicatePut ensures that putting a duplicate key into an
 // immutable treap works as expected.
 func TestImmutableDuplicatePut(t *testing.T) {
-	t.Parallel()
 
 	expectedVal := []byte("testval")
 	expectedSize := uint64(0)
@@ -370,7 +365,6 @@ func TestImmutableDuplicatePut(t *testing.T) {
 // TestImmutableNilValue ensures that putting a nil value into an immutable
 // treap results in a key being added with an empty byte slice.
 func TestImmutableNilValue(t *testing.T) {
-	t.Parallel()
 
 	key := serializeUint32(0)
 
@@ -394,7 +388,6 @@ func TestImmutableNilValue(t *testing.T) {
 // TestImmutableForEachStopIterator ensures that returning false from the ForEach
 // callback on an immutable treap stops iteration early.
 func TestImmutableForEachStopIterator(t *testing.T) {
-	t.Parallel()
 
 	// Insert a few keys.
 	numItems := 10
@@ -420,7 +413,6 @@ func TestImmutableForEachStopIterator(t *testing.T) {
 // keeping a reference to the previous treap, performing a mutation, and then
 // ensuring the referenced treap does not have the mutation applied.
 func TestImmutableSnapshot(t *testing.T) {
-	t.Parallel()
 
 	// Insert a bunch of sequential keys while checking several of the treap
 	// functions work as expected.

--- a/database/internal/treap/mutable_test.go
+++ b/database/internal/treap/mutable_test.go
@@ -13,7 +13,6 @@ import (
 // TestMutableEmpty ensures calling functions on an empty mutable treap works as
 // expected.
 func TestMutableEmpty(t *testing.T) {
-	t.Parallel()
 
 	// Ensure the treap length is the expected value.
 	testTreap := NewMutable()
@@ -55,7 +54,6 @@ func TestMutableEmpty(t *testing.T) {
 // TestMutableReset ensures that resetting an existing mutable treap works as
 // expected.
 func TestMutableReset(t *testing.T) {
-	t.Parallel()
 
 	// Insert a few keys.
 	numItems := 10
@@ -111,7 +109,6 @@ func TestMutableReset(t *testing.T) {
 // TestMutableSequential ensures that putting keys into a mutable treap in
 // sequential order works as expected.
 func TestMutableSequential(t *testing.T) {
-	t.Parallel()
 
 	// Insert a bunch of sequential keys while checking several of the treap
 	// functions work as expected.
@@ -211,7 +208,6 @@ func TestMutableSequential(t *testing.T) {
 // TestMutableReverseSequential ensures that putting keys into a mutable treap
 // in reverse sequential order works as expected.
 func TestMutableReverseSequential(t *testing.T) {
-	t.Parallel()
 
 	// Insert a bunch of sequential keys while checking several of the treap
 	// functions work as expected.
@@ -312,7 +308,6 @@ func TestMutableReverseSequential(t *testing.T) {
 // TestMutableUnordered ensures that putting keys into a mutable treap in no
 // paritcular order works as expected.
 func TestMutableUnordered(t *testing.T) {
-	t.Parallel()
 
 	// Insert a bunch of out-of-order keys while checking several of the
 	// treap functions work as expected.
@@ -389,7 +384,6 @@ func TestMutableUnordered(t *testing.T) {
 // TestMutableDuplicatePut ensures that putting a duplicate key into a mutable
 // treap updates the existing value.
 func TestMutableDuplicatePut(t *testing.T) {
-	t.Parallel()
 
 	key := serializeUint32(0)
 	val := []byte("testval")
@@ -418,7 +412,6 @@ func TestMutableDuplicatePut(t *testing.T) {
 // TestMutableNilValue ensures that putting a nil value into a mutable treap
 // results in a key being added with an empty byte slice.
 func TestMutableNilValue(t *testing.T) {
-	t.Parallel()
 
 	key := serializeUint32(0)
 
@@ -442,7 +435,6 @@ func TestMutableNilValue(t *testing.T) {
 // TestMutableForEachStopIterator ensures that returning false from the ForEach
 // callback of a mutable treap stops iteration early.
 func TestMutableForEachStopIterator(t *testing.T) {
-	t.Parallel()
 
 	// Insert a few keys.
 	numItems := 10

--- a/database/internal/treap/treapiter_test.go
+++ b/database/internal/treap/treapiter_test.go
@@ -14,7 +14,6 @@ import (
 // iterators is as expected including tests for first, last, ordered and reverse
 // ordered iteration, limiting the range, seeking, and initially unpositioned.
 func TestMutableIterator(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		numKeys       int
@@ -271,7 +270,6 @@ testLoop:
 // TestMutableEmptyIterator ensures that the various functions behave as
 // expected when a mutable treap is empty.
 func TestMutableEmptyIterator(t *testing.T) {
-	t.Parallel()
 
 	// Create iterator against empty treap.
 	testTreap := NewMutable()
@@ -321,7 +319,6 @@ func TestMutableEmptyIterator(t *testing.T) {
 // TestIteratorUpdates ensures that issuing a call to ForceReseek on an iterator
 // that had the underlying mutable treap updated works as expected.
 func TestIteratorUpdates(t *testing.T) {
-	t.Parallel()
 
 	// Create a new treap with various values inserted in no particular
 	// order.  The resulting keys are the set (2, 4, 7, 11, 18, 25).
@@ -414,7 +411,6 @@ func TestIteratorUpdates(t *testing.T) {
 // iterators is as expected including tests for first, last, ordered and reverse
 // ordered iteration, limiting the range, seeking, and initially unpositioned.
 func TestImmutableIterator(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		numKeys       int
@@ -671,7 +667,6 @@ testLoop:
 // TestImmutableEmptyIterator ensures that the various functions behave as
 // expected when an immutable treap is empty.
 func TestImmutableEmptyIterator(t *testing.T) {
-	t.Parallel()
 
 	// Create iterator against empty treap.
 	testTreap := NewImmutable()

--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -297,7 +297,6 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 // - Generate 1 more block to reach the next state transition
 //   - Assert chain height is expected and state moved to ThresholdActive
 func TestBIP0009(t *testing.T) {
-	t.Parallel()
 
 	testBIP0009(t, "dummy", chaincfg.DeploymentTestDummy)
 	testBIP0009(t, "segwit", chaincfg.DeploymentSegwit)
@@ -318,7 +317,6 @@ func TestBIP0009(t *testing.T) {
 //   - Assert bit is set for block prior to state transition (ThresholdLockedIn)
 //   - Assert bit is NOT set for block at state transition (ThresholdActive)
 func TestBIP0009Mining(t *testing.T) {
-	t.Parallel()
 
 	// Initialize the primary mining node with only the genesis block.
 	r, err := rpctest.New(&chaincfg.SimNetParams, nil, nil)

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -108,7 +108,6 @@ func makeTestOutput(r *rpctest.Harness, t *testing.T,
 //    - Transactions with final lock-times from the PoV of MTP should be
 //      accepted to the mempool and mined in future block.
 func TestBIP0113Activation(t *testing.T) {
-	t.Parallel()
 
 	pktdCfg := []string{"--rejectnonstd"}
 	r, err := rpctest.New(&chaincfg.SimNetParams, nil, pktdCfg)
@@ -400,7 +399,6 @@ func assertTxInBlock(r *rpctest.Harness, t *testing.T, blockHash *chainhash.Hash
 //    - See the cases exercised within the table driven tests towards the end
 //    of this test.
 func TestBIP0068AndBIP0112Activation(t *testing.T) {
-	t.Parallel()
 
 	// We'd like the test proper evaluation and validation of the BIP 68
 	// (sequence locks) and BIP 112 rule-sets which add input-age based

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -461,8 +461,6 @@ func testPoolMembership(tc *testContext, tx *btcutil.Tx, inOrphanPool, inTxPool 
 // they are all orphans.  Finally, it adds the linking transaction and ensures
 // the entire orphan chain is moved to the transaction pool.
 func TestSimpleOrphanChain(t *testing.T) {
-	t.Parallel()
-
 	harness, spendableOuts, err := newPoolHarness(&chaincfg.MainNetParams)
 	if err != nil {
 		t.Fatalf("unable to create test pool: %v", err)
@@ -524,7 +522,6 @@ func TestSimpleOrphanChain(t *testing.T) {
 // TestOrphanReject ensures that orphans are properly rejected when the allow
 // orphans flag is not set on ProcessTransaction.
 func TestOrphanReject(t *testing.T) {
-	t.Parallel()
 
 	harness, outputs, err := newPoolHarness(&chaincfg.MainNetParams)
 	if err != nil {
@@ -578,7 +575,6 @@ func TestOrphanReject(t *testing.T) {
 // TestOrphanEviction ensures that exceeding the maximum number of orphans
 // evicts entries to make room for the new ones.
 func TestOrphanEviction(t *testing.T) {
-	t.Parallel()
 
 	harness, outputs, err := newPoolHarness(&chaincfg.MainNetParams)
 	if err != nil {
@@ -642,7 +638,6 @@ func TestOrphanEviction(t *testing.T) {
 // orphan that doesn't exist is removed  both when there is another orphan that
 // redeems it and when there is not.
 func TestBasicOrphanRemoval(t *testing.T) {
-	t.Parallel()
 
 	const maxOrphans = 4
 	harness, spendableOuts, err := newPoolHarness(&chaincfg.MainNetParams)
@@ -717,7 +712,6 @@ func TestBasicOrphanRemoval(t *testing.T) {
 // TestOrphanChainRemoval ensure that orphan chains (orphans that spend outputs
 // from other orphans) are removed as expected.
 func TestOrphanChainRemoval(t *testing.T) {
-	t.Parallel()
 
 	const maxOrphans = 10
 	harness, spendableOuts, err := newPoolHarness(&chaincfg.MainNetParams)
@@ -780,7 +774,6 @@ func TestOrphanChainRemoval(t *testing.T) {
 // TestMultiInputOrphanDoubleSpend ensures that orphans that spend from an
 // output that is spend by another transaction entering the pool are removed.
 func TestMultiInputOrphanDoubleSpend(t *testing.T) {
-	t.Parallel()
 
 	const maxOrphans = 4
 	harness, outputs, err := newPoolHarness(&chaincfg.MainNetParams)
@@ -869,7 +862,6 @@ func TestMultiInputOrphanDoubleSpend(t *testing.T) {
 // TestCheckSpend tests that CheckSpend returns the expected spends found in
 // the mempool.
 func TestCheckSpend(t *testing.T) {
-	t.Parallel()
 
 	harness, outputs, err := newPoolHarness(&chaincfg.MainNetParams)
 	if err != nil {
@@ -938,7 +930,6 @@ func TestCheckSpend(t *testing.T) {
 // TestSignalsReplacement tests that transactions properly signal they can be
 // replaced using RBF.
 func TestSignalsReplacement(t *testing.T) {
-	t.Parallel()
 
 	testCases := []struct {
 		name               string
@@ -1056,7 +1047,6 @@ func TestSignalsReplacement(t *testing.T) {
 // unconfirmed double spends in the case of replacement and non-replacement
 // transactions.
 func TestCheckPoolDoubleSpend(t *testing.T) {
-	t.Parallel()
 
 	testCases := []struct {
 		name          string
@@ -1232,7 +1222,6 @@ func TestCheckPoolDoubleSpend(t *testing.T) {
 // TestConflicts ensures that the mempool can properly detect conflicts when
 // processing new incoming transactions.
 func TestConflicts(t *testing.T) {
-	t.Parallel()
 
 	testCases := []struct {
 		name string
@@ -1382,7 +1371,6 @@ func TestConflicts(t *testing.T) {
 // TestAncestorsDescendants ensures that we can properly retrieve the
 // unconfirmed ancestors and descendants of a transaction.
 func TestAncestorsDescendants(t *testing.T) {
-	t.Parallel()
 
 	// We'll start the test by initializing our mempool harness.
 	harness, outputs, err := newPoolHarness(&chaincfg.MainNetParams)
@@ -1459,7 +1447,6 @@ func TestAncestorsDescendants(t *testing.T) {
 // TestRBF tests the different cases required for a transaction to properly
 // replace its conflicts given that they all signal replacement.
 func TestRBF(t *testing.T) {
-	t.Parallel()
 
 	defaultFee := btcutil.UnitsPerCoin()
 

--- a/neutrino/bamboozle_unit_test.go
+++ b/neutrino/bamboozle_unit_test.go
@@ -651,7 +651,6 @@ func runCheckCFCheckptSanityTestCase(t *testing.T, testCase *cfCheckptTestCase) 
 }
 
 func TestCheckCFCheckptSanity(t *testing.T) {
-	t.Parallel()
 
 	for _, testCase := range cfCheckptTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -661,7 +660,6 @@ func TestCheckCFCheckptSanity(t *testing.T) {
 }
 
 func TestCheckForCFHeadersMismatch(t *testing.T) {
-	t.Parallel()
 
 	for _, testCase := range checkCFHTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -678,7 +676,6 @@ func TestCheckForCFHeadersMismatch(t *testing.T) {
 }
 
 func TestResolveFilterMismatchFromBlock(t *testing.T) {
-	t.Parallel()
 
 	// The correct filter should have the coinbase output and the regular
 	// script output.

--- a/neutrino/banman/codec_test.go
+++ b/neutrino/banman/codec_test.go
@@ -12,7 +12,6 @@ import (
 // TestIPNetSerialization ensures that we can serialize different supported IP
 // networks and deserialize them into their expected result.
 func TestIPNetSerialization(t *testing.T) {
-	t.Parallel()
 
 	testCases := []struct {
 		name  string

--- a/neutrino/banman/store_test.go
+++ b/neutrino/banman/store_test.go
@@ -48,7 +48,6 @@ func createTestBanStore(t *testing.T) (banman.Store, func()) {
 // TestBanStore ensures that the BanStore's state correctly reflects the
 // BanStatus of IP networks.
 func TestBanStore(t *testing.T) {
-	t.Parallel()
 
 	// We'll start by creating our test BanStore backed by a boltdb
 	// instance.

--- a/neutrino/banman/util_test.go
+++ b/neutrino/banman/util_test.go
@@ -9,8 +9,6 @@ import (
 // TestParseIPNet ensures that we can parse different combinations of
 // IPs/addresses and masks.
 func TestParseIPNet(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		name   string
 		addr   string

--- a/neutrino/blockmanager_test.go
+++ b/neutrino/blockmanager_test.go
@@ -270,7 +270,6 @@ func generateResponses(msgs []wire.Message,
 // handle checkpointed filter header query responses in out of order, and when
 // a partial interval is already written to the store.
 func TestBlockManagerInitialInterval(t *testing.T) {
-	t.Parallel()
 	var wg sync.WaitGroup
 	failed := int32(0)
 	defer func() {
@@ -451,7 +450,6 @@ func TestBlockManagerInitialInterval(t *testing.T) {
 // TestBlockManagerInvalidInterval tests that the block manager is able to
 // determine it is receiving corrupt checkpoints and filter headers.
 func TestBlockManagerInvalidInterval(t *testing.T) {
-	t.Parallel()
 	var wg sync.WaitGroup
 	failed := int32(0)
 	defer func() {
@@ -796,8 +794,6 @@ var _ QueryAccess = (*mockQueryAccess)(nil)
 // TestBlockManagerDetectBadPeers checks that we detect bad peers, like peers
 // not responding to our filter query, serving inconsistent filters etc.
 func TestBlockManagerDetectBadPeers(t *testing.T) {
-	t.Parallel()
-
 	var (
 		stopHash        = chainhash.Hash{}
 		prev            = chainhash.Hash{}

--- a/neutrino/blockntfns/manager_test.go
+++ b/neutrino/blockntfns/manager_test.go
@@ -39,7 +39,6 @@ func (s *mockNtfnSource) NotificationsSinceHeight(
 // TestManagerNewSubscription ensures that a client properly receives new
 // block notifications once it successfully registers for a subscription.
 func TestManagerNewSubscription(t *testing.T) {
-	t.Parallel()
 
 	// We'll start by creating a subscription manager backed by our mocked
 	// block source.
@@ -122,7 +121,6 @@ func TestManagerNewSubscription(t *testing.T) {
 // their subscription, that they are no longer delivered any new notifications
 // after the fact.
 func TestManagerCancelSubscription(t *testing.T) {
-	t.Parallel()
 
 	// We'll start by creating a subscription manager backed by our mocked
 	// block source.
@@ -201,7 +199,6 @@ func TestManagerCancelSubscription(t *testing.T) {
 // chain, that a historical backlog of notifications is delivered from that
 // point forwards.
 func TestManagerHistoricalBacklog(t *testing.T) {
-	t.Parallel()
 
 	// We'll start by creating a subscription manager backed by our mocked
 	// block source.

--- a/neutrino/cache/cache_test.go
+++ b/neutrino/cache/cache_test.go
@@ -16,7 +16,6 @@ import (
 // TestBlockFilterCaches tests that we can put and retrieve elements from all
 // implementations of the filter and block caches.
 func TestBlockFilterCaches(t *testing.T) {
-	t.Parallel()
 
 	const filterType = filterdb.RegularFilter
 

--- a/neutrino/cache/lru/lru_test.go
+++ b/neutrino/cache/lru/lru_test.go
@@ -40,7 +40,6 @@ func getSizeableValue(generic cache.Value, _ er.R) int {
 
 // TestEmptyCacheSizeZero will check that an empty cache has a size of 0.
 func TestEmptyCacheSizeZero(t *testing.T) {
-	t.Parallel()
 	c := NewCache(10)
 	assertEqual(t, c.Len(), 0, "")
 }
@@ -48,7 +47,6 @@ func TestEmptyCacheSizeZero(t *testing.T) {
 // TestCacheNeverExceedsSize inserts many filters into the cache and verifies
 // at each step that the cache never exceeds it's initial size.
 func TestCacheNeverExceedsSize(t *testing.T) {
-	t.Parallel()
 	c := NewCache(2)
 	c.Put(1, &sizeable{value: 1, size: 1})
 	c.Put(2, &sizeable{value: 2, size: 1})
@@ -63,7 +61,6 @@ func TestCacheNeverExceedsSize(t *testing.T) {
 // were put in the cache are always available, it will also check the eviction
 // behavior when items put in the cache exceeds cache capacity.
 func TestCacheAlwaysHasLastAccessedItems(t *testing.T) {
-	t.Parallel()
 	c := NewCache(2)
 	c.Put(1, &sizeable{value: 1, size: 1})
 	c.Put(2, &sizeable{value: 2, size: 1})
@@ -99,7 +96,6 @@ func TestCacheAlwaysHasLastAccessedItems(t *testing.T) {
 // TestElementSizeCapacityEvictsEverything tests that Cache evicts everything
 // from cache when an element with size=capacity is inserted.
 func TestElementSizeCapacityEvictsEverything(t *testing.T) {
-	t.Parallel()
 	c := NewCache(3)
 
 	c.Put(1, &sizeable{value: 1, size: 1})
@@ -130,7 +126,6 @@ func TestElementSizeCapacityEvictsEverything(t *testing.T) {
 // TestCacheFailsInsertionSizeBiggerCapacity tests that the cache fails the
 // put operation when the element's size is bigger than it's capacity.
 func TestCacheFailsInsertionSizeBiggerCapacity(t *testing.T) {
-	t.Parallel()
 	c := NewCache(2)
 
 	_, err := c.Put(1, &sizeable{value: 1, size: 3})
@@ -144,7 +139,6 @@ func TestCacheFailsInsertionSizeBiggerCapacity(t *testing.T) {
 // is evicted from the Cache, multiple smaller ones can be inserted without an
 // eviction taking place.
 func TestManySmallElementCanInsertAfterBigEviction(t *testing.T) {
-	t.Parallel()
 	c := NewCache(3)
 
 	_, err := c.Put(1, &sizeable{value: 1, size: 3})
@@ -179,7 +173,6 @@ func TestManySmallElementCanInsertAfterBigEviction(t *testing.T) {
 // replaced with a value of size smaller, that the size shrinks and we can
 // insert without an eviction taking place.
 func TestReplacingElementValueSmallerSize(t *testing.T) {
-	t.Parallel()
 	c := NewCache(2)
 
 	c.Put(1, &sizeable{value: 1, size: 2})
@@ -196,7 +189,6 @@ func TestReplacingElementValueSmallerSize(t *testing.T) {
 // TestReplacingElementValueBiggerSize tests that if an existing element is
 // replaced with a value of size bigger, that it evicts accordingly.
 func TestReplacingElementValueBiggerSize(t *testing.T) {
-	t.Parallel()
 	c := NewCache(2)
 
 	c.Put(1, &sizeable{value: 1, size: 1})
@@ -212,7 +204,6 @@ func TestReplacingElementValueBiggerSize(t *testing.T) {
 // the lru cache. When running the test, "-race" option should be passed to
 // "go test" command.
 func TestConcurrencySimple(t *testing.T) {
-	t.Parallel()
 	c := NewCache(5)
 	var wg sync.WaitGroup
 
@@ -252,7 +243,6 @@ func TestConcurrencySimple(t *testing.T) {
 // put and retrieve. When running the test, "-race" option should be passed to
 // "go test" command.
 func TestConcurrencySmallCache(t *testing.T) {
-	t.Parallel()
 	c := NewCache(5)
 	var wg sync.WaitGroup
 	failed := int32(0)
@@ -291,7 +281,6 @@ func TestConcurrencySmallCache(t *testing.T) {
 // put and retrieve. When running the test, "-race" option should be passed to
 // "go test" command.
 func TestConcurrencyBigCache(t *testing.T) {
-	t.Parallel()
 	c := NewCache(100)
 	var wg sync.WaitGroup
 	failed := int32(0)

--- a/neutrino/chainsync/filtercontrol_test.go
+++ b/neutrino/chainsync/filtercontrol_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestControlCFHeader(t *testing.T) {
-	t.Parallel()
 
 	// We'll modify our backing list of checkpoints for this test.
 	height := uint32(999)

--- a/neutrino/headerfs/store_test.go
+++ b/neutrino/headerfs/store_test.go
@@ -456,7 +456,6 @@ func TestFilterHeaderStoreRecovery(t *testing.T) {
 // the ancestors of a particular block, going from a set distance back to the
 // target block.
 func TestBlockHeadersFetchHeaderAncestors(t *testing.T) {
-	t.Parallel()
 
 	cleanUp, _, _, bhs, err := createTestBlockHeaderStore()
 	if cleanUp != nil {
@@ -519,7 +518,6 @@ func TestBlockHeadersFetchHeaderAncestors(t *testing.T) {
 // delete the current on disk filter header state if a headerStateAssertion is
 // passed in during initialization.
 func TestFilterHeaderStateAssertion(t *testing.T) {
-	t.Parallel()
 
 	const chainTip = 10
 	filterHeaderChain := createTestFilterHeaderChain(chainTip)

--- a/neutrino/headerlist/bounded_header_list_test.go
+++ b/neutrino/headerlist/bounded_header_list_test.go
@@ -9,7 +9,6 @@ import (
 // TestBoundedMemoryChainEmptyList tests the expected functionality of an empty
 // list w.r.t which methods return a nil pointer and which do not.
 func TestBoundedMemoryChainEmptyList(t *testing.T) {
-	t.Parallel()
 
 	memChain := NewBoundedMemoryChain(5)
 
@@ -45,7 +44,6 @@ func TestBoundedMemoryChainEmptyList(t *testing.T) {
 // elements, then reset the chain to nothing, it is identical to a newly
 // created chain with only that element.
 func TestBoundedMemoryChainResetHeaderState(t *testing.T) {
-	t.Parallel()
 
 	memChain := NewBoundedMemoryChain(5)
 
@@ -85,7 +83,6 @@ func TestBoundedMemoryChainResetHeaderState(t *testing.T) {
 // TestBoundedMemoryChainSizeLimit tests that if we add elements until the size
 // of the list if exceeded, then the list is properly bounded.
 func TestBoundedMemoryChainSizeLimit(t *testing.T) {
-	t.Parallel()
 
 	memChain := NewBoundedMemoryChain(5)
 
@@ -153,7 +150,6 @@ func TestBoundedMemoryChainSizeLimit(t *testing.T) {
 // can properly traverse the entire chain backwards, starting from the final
 // element.
 func TestBoundedMemoryChainPrevIteration(t *testing.T) {
-	t.Parallel()
 
 	memChain := NewBoundedMemoryChain(5)
 

--- a/neutrino/pushtx/broadcaster_test.go
+++ b/neutrino/pushtx/broadcaster_test.go
@@ -41,7 +41,6 @@ func createTx(t *testing.T, numOutputs int, inputs ...wire.OutPoint) *wire.MsgTx
 // TestBroadcaster ensures that we can broadcast transactions while it is
 // active.
 func TestBroadcaster(t *testing.T) {
-	t.Parallel()
 
 	cfg := &Config{
 		Broadcast: func(*wire.MsgTx) er.R {
@@ -77,9 +76,8 @@ func TestBroadcaster(t *testing.T) {
 // TestRebroadcast ensures that we properly rebroadcast transactions upon every
 // new block. Transactions that have confirmed should no longer be broadcast.
 func TestRebroadcast(t *testing.T) {
-	t.Parallel()
 
-	const numTxs = 3
+	const numTxs = 1
 
 	// We'll start by setting up the broadcaster with channels to mock the
 	// behavior of its external dependencies.

--- a/neutrino/pushtx/error_test.go
+++ b/neutrino/pushtx/error_test.go
@@ -12,7 +12,6 @@ import (
 // TestParseBroadcastErrorCode ensures that we properly construct a
 // BroadcastError with the appropriate error code from a wire.MsgReject.
 func TestParseBroadcastErrorCode(t *testing.T) {
-	t.Parallel()
 
 	testCases := []struct {
 		name string
@@ -102,7 +101,6 @@ func TestParseBroadcastErrorCode(t *testing.T) {
 	for _, testCase := range testCases {
 		test := testCase
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 
 			broadcastErr := pushtx.ParseBroadcastError(
 				test.msg, "127.0.0.1:8333",

--- a/neutrino/query_test.go
+++ b/neutrino/query_test.go
@@ -250,7 +250,6 @@ func TestBigFilterEvictsEverything(t *testing.T) {
 // TestBlockCache checks that blocks are inserted and fetched from the cache
 // before peers are queried.
 func TestBlockCache(t *testing.T) {
-	t.Parallel()
 
 	// Load the first 255 blocks from disk.
 	blocks, err := loadBlocks(t, blockDataFile, blockDataNet)

--- a/pktwallet/waddrmgr/db_test.go
+++ b/pktwallet/waddrmgr/db_test.go
@@ -13,7 +13,6 @@ import (
 // TestStoreMaxReorgDepth ensures that we can only store up to MaxReorgDepth
 // blocks at any given time.
 func TestStoreMaxReorgDepth(t *testing.T) {
-	t.Parallel()
 
 	teardown, db, _ := setupManager(t)
 	defer teardown()

--- a/pktwallet/waddrmgr/migrations_test.go
+++ b/pktwallet/waddrmgr/migrations_test.go
@@ -72,7 +72,6 @@ func applyMigration(t *testing.T, beforeMigration, afterMigration,
 // TestMigrationPupulateBirthdayBlock ensures that the migration to populate the
 // wallet's birthday block works as intended.
 func TestMigrationPopulateBirthdayBlock(t *testing.T) {
-	t.Parallel()
 
 	var expectedHeight int32
 	beforeMigration := func(ns walletdb.ReadWriteBucket) er.R {
@@ -139,7 +138,6 @@ func TestMigrationPopulateBirthdayBlock(t *testing.T) {
 // can properly detect a height estimate which the chain from our point of view
 // has not yet reached.
 func TestMigrationPopulateBirthdayBlockEstimateTooFar(t *testing.T) {
-	t.Parallel()
 
 	const numBlocks = 1000
 	chainParams := chaincfg.MainNetParams
@@ -221,7 +219,6 @@ func TestMigrationPopulateBirthdayBlockEstimateTooFar(t *testing.T) {
 // TestMigrationResetSyncedBlockToBirthday ensures that the wallet properly sees
 // its synced to block as the birthday block after resetting it.
 func TestMigrationResetSyncedBlockToBirthday(t *testing.T) {
-	t.Parallel()
 
 	var birthdayBlock BlockStamp
 	beforeMigration := func(ns walletdb.ReadWriteBucket) er.R {
@@ -282,7 +279,6 @@ func TestMigrationResetSyncedBlockToBirthday(t *testing.T) {
 // cannot reset our synced to block to our birthday block if one isn't
 // available.
 func TestMigrationResetSyncedBlockToBirthdayWithNoBirthdayBlock(t *testing.T) {
-	t.Parallel()
 
 	// To replicate the scenario where the database is not aware of a
 	// birthday block, we won't set one. This should cause the migration to
@@ -302,7 +298,6 @@ func TestMigrationResetSyncedBlockToBirthdayWithNoBirthdayBlock(t *testing.T) {
 // TestMigrationStoreMaxReorgDepth ensures that the storeMaxReorgDepth migration
 // works as expected under different sync scenarios.
 func TestMigrationStoreMaxReorgDepth(t *testing.T) {
-	t.Parallel()
 
 	testCases := []struct {
 		name      string

--- a/pktwallet/wallet/chainntfns_test.go
+++ b/pktwallet/wallet/chainntfns_test.go
@@ -141,7 +141,6 @@ func (s *mockBirthdayStore) SetBirthdayBlock(block waddrmgr.BlockStamp) er.R {
 // TestBirthdaySanityCheckEmptyBirthdayBlock ensures that a sanity check is not
 // done if the birthday block does not exist in the first place.
 func TestBirthdaySanityCheckEmptyBirthdayBlock(t *testing.T) {
-	t.Parallel()
 
 	chainConn := &mockChainConn{}
 
@@ -163,7 +162,6 @@ func TestBirthdaySanityCheckEmptyBirthdayBlock(t *testing.T) {
 // TestBirthdaySanityCheckVerifiedBirthdayBlock ensures that a sanity check is
 // not performed if the birthday block has already been verified.
 func TestBirthdaySanityCheckVerifiedBirthdayBlock(t *testing.T) {
-	t.Parallel()
 
 	const chainTip = 5000
 	chainConn := createMockChainConn(
@@ -205,7 +203,6 @@ func TestBirthdaySanityCheckVerifiedBirthdayBlock(t *testing.T) {
 // better birthday block candidate if our estimate happens to be too far back in
 // the chain.
 func TestBirthdaySanityCheckLowerEstimate(t *testing.T) {
-	t.Parallel()
 
 	// We'll start by defining our birthday timestamp to be around the
 	// timestamp of the 1337th block.
@@ -258,7 +255,6 @@ func TestBirthdaySanityCheckLowerEstimate(t *testing.T) {
 // better birthday block candidate if our estimate happens to be too far in the
 // chain.
 func TestBirthdaySanityCheckHigherEstimate(t *testing.T) {
-	t.Parallel()
 
 	// We'll start by defining our birthday timestamp to be around the
 	// timestamp of the 1337th block.

--- a/pktwallet/wallet/wallet_test.go
+++ b/pktwallet/wallet/wallet_test.go
@@ -10,7 +10,6 @@ import (
 // TestLocateBirthdayBlock ensures we can properly map a block in the chain to a
 //timestamp.
 func TestLocateBirthdayBlock(t *testing.T) {
-	t.Parallel()
 
 	// We'll use test chains of 30 blocks with a duration between two
 	// consecutive blocks being slightly greater than the largest margin

--- a/pktwallet/walletdb/migration/manager_test.go
+++ b/pktwallet/walletdb/migration/manager_test.go
@@ -42,7 +42,6 @@ func (m *mockMigrationManager) Versions() []migration.Version {
 // TestGetLatestVersion ensures that we can properly retrieve the latest version
 // from a slice of versions.
 func TestGetLatestVersion(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		versions      []migration.Version
@@ -105,7 +104,6 @@ func TestGetLatestVersion(t *testing.T) {
 // TestVersionsToApply ensures that the proper versions that needs to be applied
 // are returned given the current version.
 func TestVersionsToApply(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		currentVersion  uint32
@@ -205,8 +203,6 @@ func TestVersionsToApply(t *testing.T) {
 // TestUpgradeRevert ensures that we are not able to revert to a previous
 // version.
 func TestUpgradeRevert(t *testing.T) {
-	t.Parallel()
-
 	m := &mockMigrationManager{
 		currentVersion: 1,
 		versions: []migration.Version{
@@ -226,7 +222,6 @@ func TestUpgradeRevert(t *testing.T) {
 // TestUpgradeSameVersion ensures that no upgrades happen if the current version
 // matches the latest.
 func TestUpgradeSameVersion(t *testing.T) {
-	t.Parallel()
 
 	m := &mockMigrationManager{
 		currentVersion: 1,
@@ -254,7 +249,6 @@ func TestUpgradeSameVersion(t *testing.T) {
 // TestUpgradeNewVersion ensures that we can properly upgrade to a newer version
 // if available.
 func TestUpgradeNewVersion(t *testing.T) {
-	t.Parallel()
 
 	versions := []migration.Version{
 		{
@@ -289,7 +283,6 @@ func TestUpgradeNewVersion(t *testing.T) {
 // TestUpgradeMultipleVersions ensures that we can go through multiple upgrades
 // in-order to reach the latest version.
 func TestUpgradeMultipleVersions(t *testing.T) {
-	t.Parallel()
 
 	previousVersion := uint32(0)
 	versions := []migration.Version{

--- a/pktwallet/wtxmgr/kahnsort_test.go
+++ b/pktwallet/wtxmgr/kahnsort_test.go
@@ -48,7 +48,6 @@ func getOutPoint(tx *wire.MsgTx, index uint32) wire.OutPoint {
 // their dependency order under multiple scenarios. A transaction (a) can depend
 // on another (b) as long as (a) spends an output created in (b).
 func TestDependencySort(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name string
@@ -129,7 +128,6 @@ func TestDependencySort(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 
 			exp := test.setup(t)
 

--- a/pktwallet/wtxmgr/migrations_test.go
+++ b/pktwallet/wtxmgr/migrations_test.go
@@ -70,7 +70,6 @@ func applyMigration(t *testing.T,
 // TestMigrationDropTransactionHistory ensures that a transaction store is reset
 // to a clean state after dropping its transaction history.
 func TestMigrationDropTransactionHistory(t *testing.T) {
-	t.Parallel()
 
 	// checkTransactions is a helper function that will assert the correct
 	// state of the transaction store based on whether the migration has

--- a/pktwallet/wtxmgr/query_test.go
+++ b/pktwallet/wtxmgr/query_test.go
@@ -239,7 +239,6 @@ func makeBlockMeta(height int32) BlockMeta {
 }
 
 func TestStoreQueries(t *testing.T) {
-	t.Parallel()
 
 	type queryTest struct {
 		desc    string
@@ -534,7 +533,6 @@ func TestStoreQueries(t *testing.T) {
 }
 
 func TestPreviousPkScripts(t *testing.T) {
-	t.Parallel()
 
 	s, db, teardown, err := testStore()
 	defer teardown()

--- a/pktwallet/wtxmgr/tx_test.go
+++ b/pktwallet/wtxmgr/tx_test.go
@@ -100,7 +100,6 @@ func serializeTx(tx *btcutil.Tx) []byte {
 }
 
 func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
-	t.Parallel()
 
 	// Create a double spend of the received blockchain transaction.
 	dupRecvTx, _ := btcutil.NewTxFromBytes(TstRecvSerializedTx)
@@ -556,7 +555,6 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 }
 
 func TestFindingSpentCredits(t *testing.T) {
-	t.Parallel()
 
 	s, db, teardown, err := testStore()
 	if err != nil {
@@ -663,7 +661,6 @@ func spendOutputs(outputs []wire.OutPoint, outputValues ...int64) *wire.MsgTx {
 }
 
 func TestCoinbases(t *testing.T) {
-	t.Parallel()
 
 	s, db, teardown, err := testStore()
 	if err != nil {
@@ -1069,7 +1066,6 @@ func TestCoinbases(t *testing.T) {
 
 // Test moving multiple transactions from unmined buckets to the same block.
 func TestMoveMultipleToSameBlock(t *testing.T) {
-	t.Parallel()
 
 	s, db, teardown, err := testStore()
 	if err != nil {
@@ -1246,7 +1242,6 @@ func TestMoveMultipleToSameBlock(t *testing.T) {
 // NewTxRecord and NewTxRecordFromMsgTx both save the serialized transaction, so
 // manually strip it out to test this code path.
 func TestInsertUnserializedTx(t *testing.T) {
-	t.Parallel()
 
 	s, db, teardown, err := testStore()
 	if err != nil {
@@ -1313,7 +1308,6 @@ func TestInsertUnserializedTx(t *testing.T) {
 // descendants. Any balance modifications due to the unmined transaction should
 // be revered.
 func TestRemoveUnminedTx(t *testing.T) {
-	t.Parallel()
 
 	store, db, teardown, err := testStore()
 	if err != nil {
@@ -1462,7 +1456,6 @@ func TestRemoveUnminedTx(t *testing.T) {
 // TestInsertMempoolTxAlreadyConfirmed ensures that transactions that already
 // exist within the store as confirmed cannot be added as unconfirmed.
 func TestInsertMempoolTxAlreadyConfirmed(t *testing.T) {
-	t.Parallel()
 
 	store, db, teardown, err := testStore()
 	if err != nil {
@@ -1525,7 +1518,6 @@ func TestInsertMempoolTxAlreadyConfirmed(t *testing.T) {
 // that double spends an existing output within the wallet, it doesn't remove
 // any other spending transactions of the same output.
 func TestOutputsAfterRemoveDoubleSpend(t *testing.T) {
-	t.Parallel()
 
 	store, db, teardown, err := testStore()
 	if err != nil {
@@ -1798,7 +1790,6 @@ func testInsertMempoolDoubleSpendTx(t *testing.T, first bool) {
 // first spend seen is confirmed, then the second spend transaction within the
 // mempool should be removed from the wallet's store.
 func TestInsertMempoolDoubleSpendConfirmedFirstTx(t *testing.T) {
-	t.Parallel()
 	testInsertMempoolDoubleSpendTx(t, true)
 }
 
@@ -1807,7 +1798,6 @@ func TestInsertMempoolDoubleSpendConfirmedFirstTx(t *testing.T) {
 // second spend seen is confirmed, then the first spend transaction within the
 // mempool should be removed from the wallet's store.
 func TestInsertMempoolDoubleSpendConfirmSecondTx(t *testing.T) {
-	t.Parallel()
 	testInsertMempoolDoubleSpendTx(t, false)
 }
 
@@ -1816,7 +1806,6 @@ func TestInsertMempoolDoubleSpendConfirmSecondTx(t *testing.T) {
 // then the unconfirmed double spends within the mempool should be removed from
 // the wallet's store.
 func TestInsertConfirmedDoubleSpendTx(t *testing.T) {
-	t.Parallel()
 
 	store, db, teardown, err := testStore()
 	if err != nil {
@@ -1990,7 +1979,6 @@ func TestInsertConfirmedDoubleSpendTx(t *testing.T) {
 // confirmed. This can lead to outputs being duplicated in the store, which can
 // lead to creating double spends when querying the wallet's UTXO set.
 func TestAddDuplicateCreditAfterConfirm(t *testing.T) {
-	t.Parallel()
 
 	store, db, teardown, err := testStore()
 	if err != nil {

--- a/txscript/engine_test.go
+++ b/txscript/engine_test.go
@@ -16,7 +16,6 @@ import (
 // TestBadPC sets the pc to a deliberately bad result then confirms that Step()
 // and Disasm fail correctly.
 func TestBadPC(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		script, off int
@@ -82,7 +81,6 @@ func TestBadPC(t *testing.T) {
 // TestCheckErrorCondition tests the execute early test in CheckErrorCondition()
 // since most code paths are tested elsewhere.
 func TestCheckErrorCondition(t *testing.T) {
-	t.Parallel()
 
 	// tx with almost empty scripts.
 	tx := &wire.MsgTx{
@@ -150,7 +148,6 @@ func TestCheckErrorCondition(t *testing.T) {
 // TestInvalidFlagCombinations ensures the script engine returns the expected
 // error when disallowed flag combinations are specified.
 func TestInvalidFlagCombinations(t *testing.T) {
-	t.Parallel()
 
 	tests := []ScriptFlags{
 		ScriptVerifyCleanStack,
@@ -200,7 +197,6 @@ func TestInvalidFlagCombinations(t *testing.T) {
 // TestCheckPubKeyEncoding ensures the internal checkPubKeyEncoding function
 // works as expected.
 func TestCheckPubKeyEncoding(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name    string
@@ -260,7 +256,6 @@ func TestCheckPubKeyEncoding(t *testing.T) {
 // TestCheckSignatureEncoding ensures the internal checkSignatureEncoding
 // function works as expected.
 func TestCheckSignatureEncoding(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name    string

--- a/txscript/hashcache_test.go
+++ b/txscript/hashcache_test.go
@@ -56,7 +56,6 @@ func genTestTx() (*wire.MsgTx, er.R) {
 // inserted.  Conversely, ContainsHashes should return false for any items
 // _not_ in the hash cache.
 func TestHashCacheAddContainsHashes(t *testing.T) {
-	t.Parallel()
 
 	seed := time.Now().Unix()
 	rand.Seed(seed)
@@ -110,7 +109,6 @@ func TestHashCacheAddContainsHashes(t *testing.T) {
 // TestHashCacheAddGet tests that the sighashes for a particular transaction
 // are properly retrieved by the GetSigHashes function.
 func TestHashCacheAddGet(t *testing.T) {
-	t.Parallel()
 
 	rand.Seed(time.Now().Unix())
 
@@ -145,7 +143,6 @@ func TestHashCacheAddGet(t *testing.T) {
 // TestHashCachePurge tests that items are able to be properly removed from the
 // hash cache.
 func TestHashCachePurge(t *testing.T) {
-	t.Parallel()
 
 	rand.Seed(time.Now().Unix())
 

--- a/txscript/opcode_test.go
+++ b/txscript/opcode_test.go
@@ -20,7 +20,6 @@ import (
 // disabled opcodes result in a script execution failure when executed normally,
 // so the function is not called under normal circumstances.
 func TestOpcodeDisabled(t *testing.T) {
-	t.Parallel()
 
 	tests := []byte{opcode.OP_CAT, opcode.OP_SUBSTR, opcode.OP_LEFT, opcode.OP_RIGHT, opcode.OP_INVERT,
 		opcode.OP_AND, opcode.OP_OR, opcode.OP_2MUL, opcode.OP_2DIV, opcode.OP_MUL, opcode.OP_DIV, opcode.OP_MOD,
@@ -40,7 +39,6 @@ func TestOpcodeDisabled(t *testing.T) {
 // TestOpcodeDisasm tests the print function for all opcodes in both the oneline
 // and full modes to ensure it provides the expected disassembly.
 func TestOpcodeDisasm(t *testing.T) {
-	t.Parallel()
 
 	// First, test the oneline disassembly.
 

--- a/txscript/pkscript_test.go
+++ b/txscript/pkscript_test.go
@@ -10,7 +10,6 @@ import (
 // TestParsePkScript ensures that the supported script types can be parsed
 // correctly and re-derived into its raw byte representation.
 func TestParsePkScript(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string
@@ -189,7 +188,6 @@ func TestParsePkScript(t *testing.T) {
 // pkScript by looking at the input's signature script/witness attempting to
 // spend it.
 func TestComputePkScript(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name      string

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -3689,7 +3689,6 @@ func TestUnparsingInvalidOpcodes(t *testing.T) {
 // TestPushedData ensured the PushedData function extracts the expected data out
 // of various scripts.
 func TestPushedData(t *testing.T) {
-	t.Parallel()
 
 	var tests = []struct {
 		script string
@@ -3749,7 +3748,6 @@ func TestPushedData(t *testing.T) {
 
 // TestHasCanonicalPush ensures the canonicalPush function works as expected.
 func TestHasCanonicalPush(t *testing.T) {
-	t.Parallel()
 
 	for i := 0; i < 65535; i++ {
 		script, err := scriptbuilder.NewScriptBuilder().AddInt64(int64(i)).Script()
@@ -3805,7 +3803,6 @@ func TestHasCanonicalPush(t *testing.T) {
 // TestGetPreciseSigOps ensures the more precise signature operation counting
 // mechanism which includes signatures in P2SH scripts works as expected.
 func TestGetPreciseSigOps(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name      string
@@ -3856,7 +3853,6 @@ func TestGetPreciseSigOps(t *testing.T) {
 // TestGetWitnessSigOpCount tests that the sig op counting for p2wkh, p2wsh,
 // nested p2sh, and invalid variants are counted properly.
 func TestGetWitnessSigOpCount(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name string
 
@@ -3944,7 +3940,6 @@ func TestGetWitnessSigOpCount(t *testing.T) {
 // TestRemoveOpcodes ensures that removing opcodes from scripts behaves as
 // expected.
 func TestRemoveOpcodes(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name   string
@@ -4026,7 +4021,6 @@ func TestRemoveOpcodes(t *testing.T) {
 // TestRemoveOpcodeByData ensures that removing data carrying opcodes based on
 // the data they contain works as expected.
 func TestRemoveOpcodeByData(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name   string
@@ -4175,7 +4169,6 @@ func TestRemoveOpcodeByData(t *testing.T) {
 // TestIsPayToScriptHash ensures the IsPayToScriptHash function returns the
 // expected results for all the scripts in scriptClassTests.
 func TestIsPayToScriptHash(t *testing.T) {
-	t.Parallel()
 
 	for _, test := range scriptClassTests {
 		script := mustParseShortForm(test.script)
@@ -4191,7 +4184,6 @@ func TestIsPayToScriptHash(t *testing.T) {
 // TestIsPayToWitnessScriptHash ensures the IsPayToWitnessScriptHash function
 // returns the expected results for all the scripts in scriptClassTests.
 func TestIsPayToWitnessScriptHash(t *testing.T) {
-	t.Parallel()
 
 	for _, test := range scriptClassTests {
 		script := mustParseShortForm(test.script)
@@ -4207,7 +4199,6 @@ func TestIsPayToWitnessScriptHash(t *testing.T) {
 // TestIsPayToWitnessPubKeyHash ensures the IsPayToWitnessPubKeyHash function
 // returns the expected results for all the scripts in scriptClassTests.
 func TestIsPayToWitnessPubKeyHash(t *testing.T) {
-	t.Parallel()
 
 	for _, test := range scriptClassTests {
 		script := mustParseShortForm(test.script)
@@ -4223,7 +4214,6 @@ func TestIsPayToWitnessPubKeyHash(t *testing.T) {
 // TestHasCanonicalPushes ensures the canonicalPush function properly determines
 // what is considered a canonical push for the purposes of removeOpcodeByData.
 func TestHasCanonicalPushes(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string
@@ -4266,7 +4256,6 @@ func TestHasCanonicalPushes(t *testing.T) {
 // TestIsPushOnlyScript ensures the IsPushOnlyScript function returns the
 // expected results.
 func TestIsPushOnlyScript(t *testing.T) {
-	t.Parallel()
 
 	test := struct {
 		name     string
@@ -4288,7 +4277,6 @@ func TestIsPushOnlyScript(t *testing.T) {
 // TestIsUnspendable ensures the IsUnspendable function returns the expected
 // results.
 func TestIsUnspendable(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string

--- a/txscript/scriptbuilder/scriptbuilder_test.go
+++ b/txscript/scriptbuilder/scriptbuilder_test.go
@@ -15,7 +15,6 @@ import (
 // TestScriptBuilderAddOp tests that pushing opcodes to a script via the
 // ScriptBuilder API works as expected.
 func TestScriptBuilderAddOp(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string
@@ -84,7 +83,6 @@ func TestScriptBuilderAddOp(t *testing.T) {
 // TestScriptBuilderAddInt64 tests that pushing signed integers to a script via
 // the ScriptBuilder API works as expected.
 func TestScriptBuilderAddInt64(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string
@@ -153,7 +151,6 @@ func TestScriptBuilderAddInt64(t *testing.T) {
 // TestScriptBuilderAddData tests that pushing data to a script via the
 // ScriptBuilder API works as expected and conforms to BIP0062.
 func TestScriptBuilderAddData(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string
@@ -290,7 +287,6 @@ func TestScriptBuilderAddData(t *testing.T) {
 // to add data to a script don't allow the script to exceed the max allowed
 // size.
 func TestExceedMaxScriptSize(t *testing.T) {
-	t.Parallel()
 
 	// Start off by constructing a max size script.
 	builder := NewScriptBuilder()
@@ -342,7 +338,6 @@ func TestExceedMaxScriptSize(t *testing.T) {
 // TestErroredScript ensures that all of the functions that can be used to add
 // data to a script don't modify the script once an error has happened.
 func TestErroredScript(t *testing.T) {
-	t.Parallel()
 
 	// Start off by constructing a near max size script that has enough
 	// space left to add each data type without an error and force an

--- a/txscript/scriptnum_test.go
+++ b/txscript/scriptnum_test.go
@@ -29,7 +29,6 @@ func hexToBytes(s string) []byte {
 // TestScriptNumBytes ensures that converting from integral script numbers to
 // byte representations works as expected.
 func TestScriptNumBytes(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		num        scriptnum.ScriptNum
@@ -93,7 +92,6 @@ func TestScriptNumBytes(t *testing.T) {
 // TestMakeScriptNum ensures that converting from byte representations to
 // integral script numbers works as expected.
 func TestMakeScriptNum(t *testing.T) {
-	t.Parallel()
 
 	// Errors used in the tests below defined here for convenience and to
 	// keep the horizontal test size shorter.
@@ -218,7 +216,6 @@ func TestMakeScriptNum(t *testing.T) {
 // TestScriptNumInt32 ensures that the Int32 function on script number behaves
 // as expected.
 func TestScriptNumInt32(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		in   scriptnum.ScriptNum

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -89,7 +89,6 @@ func signAndCheck(msg string, tx *wire.MsgTx, idx int, inputAmt int64, pkScript 
 }
 
 func TestSignTxOutput(t *testing.T) {
-	t.Parallel()
 
 	// make key
 	// make script based on key.
@@ -1652,8 +1651,6 @@ var sigScriptTests = []tstSigScript{
 // created for the MsgTxs in txTests, since they come from the blockchain
 // and we don't have the private keys.
 func TestSignatureScript(t *testing.T) {
-	t.Parallel()
-
 	privKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), privKeyD)
 
 nexttest:

--- a/txscript/stack_test.go
+++ b/txscript/stack_test.go
@@ -35,7 +35,6 @@ func tstCheckScriptError(gotErr, wantErr er.R) er.R {
 
 // TestStack tests that all of the stack operations work as expected.
 func TestStack(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name      string

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -77,7 +77,6 @@ func newAddressScriptHash(scriptHash []byte) btcutil.Address {
 // TestExtractPkScriptAddrs ensures that extracting the type, addresses, and
 // number of required signatures from PkScripts works as intended.
 func TestExtractPkScriptAddrs(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name    string
@@ -386,7 +385,6 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 // TestCalcScriptInfo ensures the CalcScriptInfo provides the expected results
 // for various valid and invalid script pairs.
 func TestCalcScriptInfo(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name      string
@@ -605,7 +603,6 @@ func (b *bogusAddress) String() string {
 // TestPayToAddrScript ensures the PayToAddrScript function generates the
 // correct scripts for the various types of addresses.
 func TestPayToAddrScript(t *testing.T) {
-	t.Parallel()
 
 	// 1MirQ9bwyQcGVJPwKUgapu5ouK2E2Ey4gX
 	p2pkhMain, err := btcutil.NewAddressPubKeyHash(hexToBytes("e34cce70c86"+
@@ -724,7 +721,6 @@ func TestPayToAddrScript(t *testing.T) {
 // TestMultiSigScript ensures the MultiSigScript function returns the expected
 // scripts and errors.
 func TestMultiSigScript(t *testing.T) {
-	t.Parallel()
 
 	//  mainnet p2pk 13CG6SJ3yHUXo4Cr2RY4THLLJrNFuG3gUg
 	p2pkCompressedMain, err := btcutil.NewAddressPubKey(hexToBytes("02192d"+
@@ -831,7 +827,6 @@ func TestMultiSigScript(t *testing.T) {
 // TestCalcMultiSigStats ensures the CalcMutliSigStats function returns the
 // expected errors.
 func TestCalcMultiSigStats(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name   string
@@ -1060,7 +1055,6 @@ var scriptClassTests = []struct {
 // TestScriptClass ensures all the scripts in scriptClassTests have the expected
 // class.
 func TestScriptClass(t *testing.T) {
-	t.Parallel()
 
 	for _, test := range scriptClassTests {
 		script := mustParseShortForm(test.script)
@@ -1076,7 +1070,6 @@ func TestScriptClass(t *testing.T) {
 // TestStringifyClass ensures the script class string returns the expected
 // string for each script class.
 func TestStringifyClass(t *testing.T) {
-	t.Parallel()
 
 	tests := []struct {
 		name     string


### PR DESCRIPTION
This PR changes the default for most tests from running in parallel to not.

The rationale behind this is that we've been plagued by what are essentially "false positives" from Travis CI, most of which are caused by improper test parallelization rather than failures of the function under test - even when the failures are caused by the function being tested, not doing the testing with race detection enabled means there is no useful feedback, and without running multiple iterations we aren't going to reliably trigger these conditions.

This lets the test suite run serially without the need to pass flags (eg `-parallel=1 -count=1`) to `go test` and will eliminate most of these false positives, while still allowing the test suite be effective - arguably, more effective.

Many of the tests that were failing due to data race issues do so at very low rates - see https://github.com/pkt-cash/pktd/issues/128 for just one example. The Golang race detector in combination with explicitly requesting parallel tests is going to be the only real effective way to get useful results when a test is failing in such a manner, and the proper way we should be running these parallelized tests and with a high iteration count and race detection enabled to ensure that the data is useful.

In short, all the random failures from CI/CD when changing a comment or documentation are *less than useful*, to say the least, and often caused by improperly written tests rather than the testing target. As mentioned previously, properly running the test suite in parallel requires more than one iteration of each test, and parallelized test failures without the use of the race detector
do not produce any useful feedback for knowing what is causing the failing test to actually fail - so there is no real downside to this approach.

I will submit a future PR that does do proper parallel testing, by using proper parallelized tests:

It seems, strangely, in Golang, the use of t.Parallel(): `"signals that this test is to be run in parallel with (and only with) other parallel tests. When a test is run multiple times due to use of -test.count or -test.cpu, multiple instances of a single test never run in parallel with each other."` confirming that the "random test failures" we are seeing are the result of other concurrent tests being run and and not necessarily even caused by the function under test: if these are genuine races (genuine being conditions that would actually arise in the source code, and not artificially created by a poorly written test itself), then doing these tests in combination with the race detector will enable actual useful feedback, rather than the useless CI feedback we get now.

I'm already working on these new tests that are properly and explicitly parallelized with goroutines, thus useful for detecting problems within the function or appropriate to the condition being tested, rather than just the random failures from the interactions with other running tests we have now.

Those will be sent as a separate pull request, once they are ready - and properly tested, with their own tests.

*(Yo dawg we heard you like tests so we put some tests in your tests so you can test while you test)*
