### PR TITLE
Optimization of Base58 Encode/Deocde: 2X-14X ++

### DIFF
--- a/btcutil/base58/base58.go
+++ b/btcutil/base58/base58.go
@@ -10,24 +10,63 @@ import (
 
 //go:generate go run genalphabet.go
 
-var bigRadix = big.NewInt(58)
+var bigRadix = [...]*big.Int{
+	big.NewInt(0),
+	big.NewInt(58),
+	big.NewInt(58 * 58),
+	big.NewInt(58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58 * 58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58 * 58 * 58 * 58 * 58),
+	big.NewInt(58 * 58 * 58 * 58 * 58 * 58 * 58 * 58 * 58),
+	bigRadix10,
+}
+
+var bigRadix10 = big.NewInt(58 * 58 * 58 * 58 * 58 * 58 * 58 * 58 * 58 * 58) // 58^10
 var bigZero = big.NewInt(0)
 
 // Decode decodes a modified base58 string to a byte slice.
 func Decode(b string) []byte {
 	answer := big.NewInt(0)
-	j := big.NewInt(1)
-
 	scratch := new(big.Int)
-	for i := len(b) - 1; i >= 0; i-- {
-		tmp := b58[b[i]]
-		if tmp == 255 {
-			return []byte("")
+
+	// Calculating with big.Int is slow for each iteration.
+	//    x += b58[b[i]] * j
+	//    j *= 58
+	//
+	// Instead we can try to do as much calculations on int64.
+	// We can represent a 10 digit base58 number using an int64.
+	//
+	// Hence we'll try to convert 10, base58 digits at a time.
+	// The rough idea is to calculate `t`, such that:
+	//
+	//   t := b58[b[i+9]] * 58^9 ... + b58[b[i+1]] * 58^1 + b58[b[i]] * 58^0
+	//   x *= 58^10
+	//   x += t
+	//
+	// Of course, in addition, we'll need to handle boundary condition when `b` is not multiple of 58^10.
+	// In that case we'll use the bigRadix[n] lookup for the appropriate power.
+	for t := b; len(t) > 0; {
+		n := len(t)
+		if n > 10 {
+			n = 10
 		}
-		scratch.SetInt64(int64(tmp))
-		scratch.Mul(j, scratch)
+		answer.Mul(answer, bigRadix[n])
+
+		total := uint64(0)
+		for i := 0; i < n; i++ {
+			tmp := b58[t[i]]
+			if tmp == 255 {
+				return []byte("")
+			}
+			total = total*58 + uint64(tmp)
+		}
+		scratch.SetUint64(total)
 		answer.Add(answer, scratch)
-		j.Mul(j, bigRadix)
+
+		t = t[n:]
 	}
 
 	tmpval := answer.Bytes()
@@ -51,10 +90,32 @@ func Encode(b []byte) string {
 	x.SetBytes(b)
 
 	answer := make([]byte, 0, len(b)*136/100)
+	mod := new(big.Int)
 	for x.Cmp(bigZero) > 0 {
-		mod := new(big.Int)
-		x.DivMod(x, bigRadix, mod)
-		answer = append(answer, alphabet[mod.Int64()])
+		// Calculating with big.Int is slow for each iteration.
+		//    x, mod = x / 58, x % 58
+		//
+		// Instead we can try to do as much calculations on int64.
+		//    x, mod = x / 58^10, x % 58^10
+		//
+		// Which will give us mod, which is 10 digit base58 number.
+		// We'll loop that 10 times to convert to the answer.
+
+		x.DivMod(x, bigRadix10, mod)
+		if x.Cmp(bigZero) == 0 {
+			// When x = 0, we need to ensure we don't add any extra zeros.
+			m := mod.Int64()
+			for m > 0 {
+				answer = append(answer, alphabet[m%58])
+				m /= 58
+			}
+		} else {
+			m := mod.Int64()
+			for i := 0; i < 10; i++ {
+				answer = append(answer, alphabet[m%58])
+				m /= 58
+			}
+		}
 	}
 
 	// leading zero bytes

--- a/btcutil/base58/base58.go
+++ b/btcutil/base58/base58.go
@@ -31,7 +31,6 @@ var bigZero = big.NewInt(0)
 func Decode(b string) []byte {
 	answer := big.NewInt(0)
 	scratch := new(big.Int)
-
 	// Calculating with big.Int is slow for each iteration.
 	//    x += b58[b[i]] * j
 	//    j *= 58

--- a/btcutil/base58/base58bench_test.go
+++ b/btcutil/base58/base58bench_test.go
@@ -11,25 +11,37 @@ import (
 	"github.com/pkt-cash/pktd/btcutil/base58"
 )
 
-func BenchmarkBase58Encode(b *testing.B) {
-	b.StopTimer()
-	data := bytes.Repeat([]byte{0xff}, 5000)
-	b.SetBytes(int64(len(data)))
-	b.StartTimer()
+var (
+	raw5k       = bytes.Repeat([]byte{0xff}, 5000)
+	raw100k     = bytes.Repeat([]byte{0xff}, 100*1000)
+	encoded5k   = base58.Encode(raw5k)
+	encoded100k = base58.Encode(raw100k)
+)
 
+func BenchmarkBase58Encode_5K(b *testing.B) {
+	b.SetBytes(int64(len(raw5k)))
 	for i := 0; i < b.N; i++ {
-		base58.Encode(data)
+		base58.Encode(raw5k)
 	}
 }
 
-func BenchmarkBase58Decode(b *testing.B) {
-	b.StopTimer()
-	data := bytes.Repeat([]byte{0xff}, 5000)
-	encoded := base58.Encode(data)
-	b.SetBytes(int64(len(encoded)))
-	b.StartTimer()
-
+func BenchmarkBase58Encode_100K(b *testing.B) {
+	b.SetBytes(int64(len(raw100k)))
 	for i := 0; i < b.N; i++ {
-		base58.Decode(encoded)
+		base58.Encode(raw100k)
+	}
+}
+
+func BenchmarkBase58Decode_5K(b *testing.B) {
+	b.SetBytes(int64(len(encoded5k)))
+	for i := 0; i < b.N; i++ {
+		base58.Decode(encoded5k)
+	}
+}
+
+func BenchmarkBase58Decode_100K(b *testing.B) {
+	b.SetBytes(int64(len(encoded100k)))
+	for i := 0; i < b.N; i++ {
+		base58.Decode(encoded100k)
 	}
 }


### PR DESCRIPTION
* Port of https://github.com/egonelbre/btcutil/commits/perf

Before:
    BenchmarkBase58Decode_5K-32     266      4373774 ns/op  1.56 MB/s
    BenchmarkBase58Decode_100K-32   1     1516196700 ns/op  0.09 MB/s
    BenchmarkBase58Encode_5K-32     46      23934763 ns/op  0.21 MB/s
    BenchmarkBase58Encode_100K-32   1     9351948600 ns/op  0.01 MB/s
After:
    BenchmarkBase58Decode_5K-32     3868      277944 ns/op  24.57 MB/s
    BenchmarkBase58Decode_100K-32   13      83772100 ns/op   1.63 MB/s
    BenchmarkBase58Encode_5K-32     501       2419129 ns/op  2.07 MB/s
    BenchmarkBase58Encode_100K-32   2       923507950 ns/op  0.11 MB/s

Same code in use here, with similar improvement noted.
