### PR TITLE
Update for Travis CI dplv2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
     - git reset --hard
     - ./do
     - gem install -N fpm --version '=1.11.0'
-    - bash -c 'cd `gem which fpm` && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
+    - bash -c 'cd $(dirname `gem which fpm`) && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
     - bash -x ./contrib/deb/build.sh
     - bash -x ./contrib/rpm/build.sh
   - os: osx
@@ -24,7 +24,7 @@ jobs:
     - git reset --hard
     - ./do
     - gem install -N fpm --version '=1.11.0'
-    - bash -c 'cd `gem which fpm` && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
+    - bash -c 'cd $(dirname `gem which fpm`) && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
     - bash -x ./contrib/macos/build.sh
 deploy:
   edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,13 +27,12 @@ jobs:
         packages:
         - coreutils
         - gnu-sed
-        update: true
     script:
     - git diff
     - git reset --hard
     - ./do
     - gem install -N fpm --version '=1.11.0'
-    - bash -c 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:/usr/local/opt/coreutils/libexec/gnubin:$PATH" && cd $(dirname `gem which fpm`) && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
+    - bash -c 'brew update && export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:/usr/local/opt/coreutils/libexec/gnubin:$PATH" && cd $(dirname `gem which fpm`) && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
     - bash -x ./contrib/macos/build.sh
 deploy:
   edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
     - gem install --no-document fpm
     - bash -x ./contrib/macos/build.sh
 deploy:
+  edge: true
   provider: releases
   api_key:
     secure: NMxpJBSdsTzw/GptBg6Uzv6b5hoMjO9UkPChzu2ef6NZvX6BITNDxPvuTMiFGuGhIIMphkdpQMzp+PweoQxqQXmhEsTlbGMVS/14ce6+kit9n0y02uYeP5oodVFrw7l2f9wMCo2q59yGvFZxXvcnyXoPR9frCkNR/7QJPdbeKP2xgwOamXll3x+GRNZVQVYrlb86LqEF0WkHsckLQUkjcUpl3CAqH1otocdrb2E6Myafhisugidlz5Egwcmotj8PaJZgwpvSCZ6ccjW7RKT3ETBGiQRJtUEaGZmxJ5+2MZG8nr8bTuZTuNTUBZVV2BdRr5ZihM5khehhH4UhOpr76PmFT9WvnPIIMmC8LofhdInua/h/Ynwcok32+BSKBlKkIVITVIhSnRsuHHJnGB7vnWu3UU8hQoIrAX4D3+lX69f9QeXzWv+z6xN9JoCrEZfTQvWiE4jrz1V2uj6FHkmHC5k+LX454om/la9I9RZ4oOmiTjfG9oLPGsncoo34zcEPzbku4ojvMZLQ6pJ4JjfDO7qKQnQTXk4sDLNsnbf7fiow7yng3D6gfHgoX3sLcFRmH5kNDLcccEtSqqhzAEBTRJx5nmeCrKthzqy9YVyJHVkD1oVCDOf5cZmkLHUMNSXdIJYB06ZXeOr8aqfLp71O0/DinBLHgcGHqDQcdB4UcAk=
@@ -36,4 +37,3 @@ deploy:
   on:
     repo: pkt-cash/pktd
     tags: true
-  skip_cleanup: 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     - git reset --hard
     - ./do
     - gem install -N fpm --version '=1.11.0'
-    - bash -c 'export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH" && cd $(dirname `gem which fpm`) && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
+    - bash -c 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:/usr/local/opt/coreutils/libexec/gnubin:$PATH" && cd $(dirname `gem which fpm`) && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
     - bash -x ./contrib/macos/build.sh
 deploy:
   edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     - git reset --hard
     - ./do
     - gem install -N fpm --version '=1.11.0'
-    - bash -c 'brew update && export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:/usr/local/opt/coreutils/libexec/gnubin:$PATH" && cd $(dirname `gem which fpm`) && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
+    - bash -c 'brew update && brew install coreutils findutils gnu-sed && PATH="/usr/local/opt/gnu-sed/libexec/gnubin:/usr/local/opt/coreutils/libexec/gnubin:$PATH" && cd $(dirname `gem which fpm`) && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
     - bash -x ./contrib/macos/build.sh
 deploy:
   edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ jobs:
     - git diff
     - git reset --hard
     - ./do
-    - gem install --no-document fpm
+    - gem install -N fpm 1.11.0
+    - bash -c 'cd $HOME/.gem/ruby/gems/fpm-1.11.0 && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
     - bash -x ./contrib/deb/build.sh
     - bash -x ./contrib/rpm/build.sh
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,19 @@ jobs:
     - bash -x ./contrib/deb/build.sh
     - bash -x ./contrib/rpm/build.sh
   - os: osx
+    cache:
+    - directories:
+      - /usr/local/Homebrew
+    addons:
+      homebrew:
+        packages:
+        - coreutils
     script:
     - git diff
     - git reset --hard
     - ./do
     - gem install -N fpm --version '=1.11.0'
-    - bash -c 'cd $(dirname `gem which fpm`) && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
+    - bash -c 'export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH" && cd $(dirname `gem which fpm`) && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
     - bash -x ./contrib/macos/build.sh
 deploy:
   edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     - git reset --hard
     - ./do
     - gem install -N fpm --version '=1.11.0'
-    - bash -c 'cd `gen which fpm` && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
+    - bash -c 'cd `gem which fpm` && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
     - bash -x ./contrib/macos/build.sh
 deploy:
   edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
         packages:
         - coreutils
         - gnu-sed
+        update: true
     script:
     - git diff
     - git reset --hard

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.15.3
+go: 1.15.5
 env:
   - PKT_FAIL_DIRTY=1
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ jobs:
     - git diff
     - git reset --hard
     - ./do
-    - gem install -N fpm 1.11.0
-    - bash -c 'cd $HOME/.gem/ruby/gems/fpm-1.11.0 && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
+    - gem install -N fpm --version '=1.11.0'
+    - bash -c 'cd `gem which fpm` && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
     - bash -x ./contrib/deb/build.sh
     - bash -x ./contrib/rpm/build.sh
   - os: osx
@@ -23,7 +23,8 @@ jobs:
     - git diff
     - git reset --hard
     - ./do
-    - gem install --no-document fpm
+    - gem install -N fpm --version '=1.11.0'
+    - bash -c 'cd `gen which fpm` && cd .. && find . -type f -print0 | xargs -0 sed -i "s#^require \"backports\"#require \"backports/latest\"#g"'
     - bash -x ./contrib/macos/build.sh
 deploy:
   edge: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
       homebrew:
         packages:
         - coreutils
+        - gnu-sed
     script:
     - git diff
     - git reset --hard


### PR DESCRIPTION
- Update Travis to build using Go 1.15.5
- Update Travis for dplv2, removed depreciated call

- Patch FPM to avoid backports deprecation warning.
- Use RVM/GEM-version agnostic method to find the FPM library path for patching.
- Apparently the default version of OS X is relatively ancient macOS 10.13... workaround that w/coreutils and GNU sed to avoid adding new scripts and possibly producing a binary that requires much newer OS.
- Also, their default HB is years out of date as well, and the online documentation is wildly incorrect regarding the default OS version capabilities. *sigh*

Edit: Closing this an simply giving up on trying to patch FPM and work with their ancient OS X - apparently decred and mainline btcd have dropped Travis CI and use GitHub Actions now for similar reasons, but I'm not about to push such an invasive change, so FPM will just produce it's warnings and soon stop working - we'll deal with it then.