### PR TITLE
Enable deterministic order for tests and coverage

### DIFF
--- a/cov_report.sh
+++ b/cov_report.sh
@@ -53,9 +53,9 @@ export CGO_ENABLED=0
 export TEST_FLAGS='-count=1 -cover -parallel=1'
 export GOFLAGS='-tags=osnetgo,osusergo'
 # shellcheck disable=SC2155
-export PKT_TARGETS="$(go list ./... | sort | uniq)"
+export PKT_TARGETS="$(go list ./... | grep -v test | sort | uniq)"
 # shellcheck disable=SC2155
-export LDB_TARGETS="$(cd goleveldb/leveldb && go list ./... | sort | uniq)"
+export LDB_TARGETS="$(cd goleveldb/leveldb && go list ./... | grep -v test | sort | uniq)"
 
 type gocov 1>/dev/null 2>&1; # shellcheck disable=SC2181
 if [ "${?}" -ne 0 ]; then

--- a/do
+++ b/do
@@ -12,7 +12,7 @@ export PKTD_LDFLAGS="-X github.com/pkt-cash/pktd/pktconfig/version.appBuild=${PK
 mkdir -p "${bindir:?${unset:?}}" || die "Failed to create output directory; aborting."
 build pktd && build pktwallet && build pktctl
 printf '%s\n' "Running tests"; # shellcheck disable=SC2086,SC2046
-{ go test ${PKTD_TESTFLAGS:?${unset:?}} $(go list ./... | sort | uniq); } || die "One or more tests failed."; # shellcheck disable=SC2086,SC2046,SC2015
-if [ -n "${LDB_TEST:-}" ]; then (cd goleveldb/leveldb && go test ${PKTD_TESTFLAGS:?${unset:?}} $(go list ./... | sort | uniq) || die "One or more tests failed."); fi
+{ go test ${PKTD_TESTFLAGS:?${unset:?}} $(go list ./... | grep -v test | sort | uniq); } || die "One or more tests failed."; # shellcheck disable=SC2086,SC2046,SC2015
+if [ -n "${LDB_TEST:-}" ]; then (cd goleveldb/leveldb && go test ${PKTD_TESTFLAGS:?${unset:?}} $(go list ./... | grep -v test | sort | uniq) || die "One or more tests failed."); fi
 "${bindir?${unset:?}}/pktd" --version || die "Unable to run compiled pktd executable."; # shellcheck disable=SC2250
 printf '%s\n' "Success! $( (cd "${bindir:?${unset:?}}" 2>/dev/null && d=$(pwd -P 2>/dev/null) && printf '%s\n' "Compiled output is located at ${d:?${bindir:?$unset}}." 2>/dev/null) 2>/dev/null )"

--- a/do
+++ b/do
@@ -11,7 +11,8 @@ fi
 export PKTD_LDFLAGS="-X github.com/pkt-cash/pktd/pktconfig/version.appBuild=${PKTD_GIT_ID:?${unset:?}}"
 mkdir -p "${bindir:?${unset:?}}" || die "Failed to create output directory; aborting."
 build pktd && build pktwallet && build pktctl
-printf '%s\n' "Running tests"; # shellcheck disable=SC2086
-go test ${PKTD_TESTFLAGS:?${unset:?}} ./... || die "One or more tests failed."
+printf '%s\n' "Running tests"; # shellcheck disable=SC2086,SC2046
+{ go test ${PKTD_TESTFLAGS:?${unset:?}} $(go list ./... | sort | uniq); } || die "One or more tests failed."; # shellcheck disable=SC2086,SC2046,SC2015
+if [ -n "${LDB_TEST:-}" ]; then (cd goleveldb/leveldb && go test ${PKTD_TESTFLAGS:?${unset:?}} $(go list ./... | sort | uniq) || die "One or more tests failed."); fi
 "${bindir?${unset:?}}/pktd" --version || die "Unable to run compiled pktd executable."; # shellcheck disable=SC2250
 printf '%s\n' "Success! $( (cd "${bindir:?${unset:?}}" 2>/dev/null && d=$(pwd -P 2>/dev/null) && printf '%s\n' "Compiled output is located at ${d:?${bindir:?$unset}}." 2>/dev/null) 2>/dev/null )"


### PR DESCRIPTION
* Enables deterministic ordering for tests and coverage
* Using "go list" will eliminate any multiple inclusions, speeding up coverage generation
* Added LDB_TEST variable to enable LevelDB tests
* Fixed scripts EOF with POSIX-compliant newlines
* Add shellcheck linter hinting where appropriate
* Exclude test directories from testing and coverage