### PR TITLE
GoLevelDB: Remove unneeded comparison

### DIFF
--- a/goleveldb/leveldb/session_record.go
+++ b/goleveldb/leveldb/session_record.go
@@ -201,7 +201,7 @@ func (p *sessionRecord) readUvarintMayEOF(field string, r io.ByteReader, mayEOF 
 	}
 	x, err := binary.ReadUvarint(r)
 	if err != nil {
-		if err == io.ErrUnexpectedEOF || (mayEOF == false && err == io.EOF) {
+		if err == io.ErrUnexpectedEOF || (!mayEOF && err == io.EOF) {
 			p.err = errors.NewErrCorrupted(storage.FileDesc{}, &ErrManifestCorrupted{field, "short read"})
 		} else if strings.HasPrefix(err.Error(), "binary:") {
 			p.err = errors.NewErrCorrupted(storage.FileDesc{}, &ErrManifestCorrupted{field, err.Error()})


### PR DESCRIPTION
* Not a particularly hot codepath, but, microbenchmarking with `go bench` actually confirms current Go optimizer somehow produces 25% shorter assembly output for cases of !value vs. if value == false.

(*Edit: Thanks VTune* :1st_place_medal: )