### PR TITLE
Seed the RNG w/CSPRNG for higher quality cookies

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,6 +6,8 @@
 package main
 
 import (
+	crand "crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -743,7 +745,9 @@ func loadConfig() (*config, []string, er.R) {
 		pktdLog.Infof("Creating a .cookie file")
 		cookiePath := filepath.Join(defaultHomeDir, ".cookie")
 		var buf [32]byte
-		if _, errr := rand.Read(buf[:]); errr != nil {
+		var src cryptoSource
+		rnd := rand.New(src)
+		if _, errr := rnd.Read(buf[:]); errr != nil {
 			err := er.E(errr)
 			err.AddMessage("Unable to get random numbers")
 			return nil, nil, err
@@ -1000,4 +1004,20 @@ func pktdDial(addr net.Addr) (net.Conn, er.R) {
 // function depending on the configuration options.
 func pktdLookup(host string) ([]net.IP, er.R) {
 	return cfg.lookup(host)
+}
+
+type cryptoSource struct{}
+
+func (s cryptoSource) Seed(seed int64) {}
+
+func (s cryptoSource) Int63() int64 {
+    return int64(s.Uint64() & ^uint64(1<<63))
+}
+
+func (s cryptoSource) Uint64() (v uint64) {
+    err := binary.Read(crand.Reader, binary.BigEndian, &v)
+    if err != nil {
+		panic("CSPRNG failure: Could not read random numbers")
+    }
+    return v
 }


### PR DESCRIPTION
* Crypto-nerd pedantic change as cookie file is written with restrictive permissions, but standard Golang math/rand implementation is rather crap and any overhead from additional RNG seeding once per `pktd` start-up is so low enough to be essentially immeasurable across 150k runs.
* Edit: Verified (default) Golang runtime entropy retrieval on all our supported platforms is non-blocking, so no risk of causing any start-up time regressions in virtualized environments or when system entropy pool is near-exhausted. 