### PR TITLE
 Bugfix dep update, drop depreciated API, misc opt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,9 +23,12 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkt-cash/pktd/goleveldb v0.0.0
 	github.com/sethgrid/pester v1.1.1-0.20200617174401-d2ad9ec9a8b6
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
+	golang.org/x/sys v0.0.0-20201126233918-771906719818 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	github.com/stretchr/testify v1.6.1 // indirect
 	go.etcd.io/bbolt v1.3.6-0.20200807205753-f6be82302843
-	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897
+	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392
 	google.golang.org/genproto v0.0.0-20201021134325-0d71844de594 // indirect
 	google.golang.org/grpc v1.34.0-dev.0.20201021230544-4e8458e5c638
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect

--- a/goleveldb/leveldb/testutil/kv.go
+++ b/goleveldb/leveldb/testutil/kv.go
@@ -343,7 +343,7 @@ func KeyValue_Generate(rnd *rand.Rand, n, incr, minlen, maxlen, vminlen, vmaxlen
 			key[j] = keymap[gen[j]]
 		}
 		value := make([]byte, rrand(vminlen, vmaxlen))
-		for n := copy(value, []byte(fmt.Sprintf("v%d", i))); n < len(value); n++ {
+		for n := copy(value, fmt.Sprintf("v%d", i)); n < len(value); n++ {
 			value[n] = 'x'
 		}
 		kv.Put(key, value)

--- a/pktwallet/internal/prompt/prompt.go
+++ b/pktwallet/internal/prompt/prompt.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pkt-cash/pktd/btcutil/hdkeychain"
 	"github.com/pkt-cash/pktd/pktwallet/internal/legacy/keystore"
 	"github.com/pkt-cash/pktd/pktwallet/wallet/seedwords"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // ProvideSeed is used to prompt for the wallet seed which maybe required during
@@ -53,7 +53,7 @@ func ProvidePrivPassphrase() ([]byte, er.R) {
 	prompt := "Enter the private passphrase of your wallet: "
 	for {
 		fmt.Print(prompt)
-		pass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		pass, err := term.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return nil, er.E(err)
 		}
@@ -122,7 +122,7 @@ func promptPass(reader *bufio.Reader, prefix string, confirm bool) ([]byte, er.R
 	prompt := fmt.Sprintf("%s: ", prefix)
 	for {
 		fmt.Print(prompt)
-		pass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		pass, err := term.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return nil, er.E(err)
 		}
@@ -137,7 +137,7 @@ func promptPass(reader *bufio.Reader, prefix string, confirm bool) ([]byte, er.R
 		}
 
 		fmt.Print("Confirm passphrase: ")
-		confirm, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		confirm, err := term.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			return nil, er.E(err)
 		}

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -125,8 +125,8 @@ func parseShortForm(script string) ([]byte, er.R) {
 	}
 
 	// Split only does one separator so convert all \n and tab into  space.
-	script = strings.Replace(script, "\n", " ", -1)
-	script = strings.Replace(script, "\t", " ", -1)
+	script = strings.ReplaceAll(script, "\n", " ")
+	script = strings.ReplaceAll(script, "\t", " ")
 	tokens := strings.Split(script, " ")
 	builder := scriptbuilder.NewScriptBuilder()
 


### PR DESCRIPTION

- Vetted x/crypto 20201016220609 > 20201124201722
 * Fixes support for IBM z/OS on S/390X
 * Removes non-crypto functions from x/crypto
   * Terminal functions moved to x/term
 * c8d3bf9c5392d5f66747f112cd55055d7a530b19
   * ^ Fixes blatantly wrong benchmarking test
 * Updating avoids failure to compile with 1.16

- Add x/term, all terminal functions moved here

- Bump of related sys and net dependencies
  * *Many* fixes of lots of Windows-specific bugs
  * Fixes support for IBM z/OS on S/390X
  * Fixes compiling with GCC 10+ GCCGo
  * Fixes race condition bugs in net/http2
  * Update to Unicode 13 - resolves IDNA failures

- leveldb/testutil: Remove unnecessary conversion

- pktwallet/internal/prompt: Drop depreciated API

- txscript test: Replace -> faster ReplaceAll

- go vet

