### PR TITLE
peer: Improve loop/self-connection detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pkt-cash/pktd/goleveldb v0.0.0
 	github.com/sethgrid/pester v1.1.1-0.20200617174401-d2ad9ec9a8b6
+	github.com/sony/sonyflake v1.0.1-0.20200827011719-848d664ceea4
 	github.com/stretchr/testify v1.6.1 // indirect
 	go.etcd.io/bbolt v1.3.6-0.20200807205753-f6be82302843
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1910,6 +1910,7 @@ out:
 				} else {
 					nonce := uint64(rand.Int63())
 				}
+			}
 			p.QueueMessage(wire.NewMsgPing(nonce), nil)
 			sentNonces.Add(nonce)
 

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1898,17 +1898,18 @@ func (p *Peer) pingHandler() {
 	sfrotate()
 	pingTicker := time.NewTicker(pingInterval)
 	defer pingTicker.Stop()
-
+	var nonce uint64
+	var err error
 out:
 	for {
 		select {
 		case <-pingTicker.C:
 			if sf != nil {
-				nonce, err := sf.NextID()
+				nonce, err = sf.NextID()
 				if err != nil {
 					continue
 				} else {
-					nonce := uint64(rand.Int63())
+					nonce = uint64(rand.Int63())
 				}
 			}
 			p.QueueMessage(wire.NewMsgPing(nonce), nil)


### PR DESCRIPTION
  *  Improve loop/self-detection detection
  *  Use Sonyflake nonces, with PRNG fallback
  *  Reize the MRU nonce map to 384 entries


