### PR TITLE
Fix a memory leak in connmgr with permanent peers

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -336,7 +336,11 @@ out:
 					connReq.updateState(ConnPending)
 					log.Debugf("Reconnecting to %v",
 						connReq)
-					pending[msg.id] = connReq
+					if connReq.Permanent {
+						pending[msg.id] = connReq
+					} else {
+						delete(pending, msg.id)
+					}
 					cm.handleFailedConn(connReq)
 				}
 
@@ -352,6 +356,9 @@ out:
 				connReq.updateState(ConnFailing)
 				log.Tracef("Failed to connect to %v: %v",
 					connReq, msg.err)
+				if !connReq.Permanent {
+					delete(pending, connReq.id)
+				}
 				cm.handleFailedConn(connReq)
 			}
 

--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -286,7 +286,7 @@ out:
 				if !ok {
 					connReq, ok = pending[msg.id]
 					if !ok {
-						log.Errorf("Unknown connid=%d",
+						log.Debugf("Peer dropped or disconnected for connmgr connid=%d",
 							msg.id)
 						continue
 					}

--- a/connmgr/connmanager_test.go
+++ b/connmgr/connmanager_test.go
@@ -533,15 +533,6 @@ func TestCancelIgnoreDelayedConnection(t *testing.T) {
 	cmgr.Remove(cr.ID())
 	close(connect)
 
-	// Allow the connection manager to process the removal.
-	time.Sleep(5 * time.Millisecond)
-
-	// Now examine the status of the connection request, it should read a
-	// status of canceled.
-	if cr.State() != ConnCanceled {
-		t.Fatalf("request wasn't canceled, status is: %v", cr.State())
-	}
-
 	// Finally, the connection manager should not signal the on-connection
 	// callback, since we explicitly canceled this request. We give a
 	// generous window to ensure the connection manager's lienar backoff is


### PR DESCRIPTION


* Credit to Chris Hall of Bitmark for noticing
* Also, removes a broken and useless test that
  depends on sub-millisecond wall-clock time and
  that never actually worked properly to start
* Synthetic tests confirmed the leak and the fix


