### PR TITLE
Fix config file and command line parsing

### DIFF
--- a/pktwallet/internal/cfgutil/explicitflags.go
+++ b/pktwallet/internal/cfgutil/explicitflags.go
@@ -24,3 +24,13 @@ func NewExplicitString(defaultValue string) *ExplicitString {
 // ExplicitlySet returns whether the flag was explicitly set through the
 // flags.Unmarshaler interface.
 func (e *ExplicitString) ExplicitlySet() bool { return e.explicitlySet }
+
+// MarshalFlag implements the flags.Marshaler interface.
+func (e *ExplicitString) MarshalFlag() (string, error) { return e.Value, nil }
+
+// UnmarshalFlag implements the flags.Unmarshaler interface.
+func (e *ExplicitString) UnmarshalFlag(value string) error {
+	e.Value = value
+	e.explicitlySet = true
+	return nil
+}


### PR DESCRIPTION
Command line args and config file entries were ignored. This should let you specify a config file or data directory. (`--appdata=/some/dir`)