### PR TITLE
Dynamicbanscore

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -515,7 +515,6 @@ var PktTestNetParams = Params{
 	DNSSeeds: []DNSSeed{
 		{"testseed.cjd.li", false},
 		{"testseed.anode.co", false},
-		{"testseed.gridfinity.com", false},
 	},
 
 	// Chain parameters
@@ -598,7 +597,6 @@ var PktMainNetParams = Params{
 	DNSSeeds: []DNSSeed{
 		{"seed.cjd.li", false},
 		{"seed.anode.co", false},
-		{"seed.gridfinity.com", false},
 	},
 
 	// Chain parameters


### PR DESCRIPTION
Sometimes connected peers get banned because of "InvalidFilterHeaders". If there is no syncpartner left no transactions can be done for several hours.
dynamicbanscore is already available in pktd. This changes implement the score in pktwallet so peers won't get banned immediately.

Every missbehaving of a peer will increasse its score by 33.
If a BanScore of 100 is reached, the peer will be disconnected.
Every minute the score is decaying to one half of it's original value.

More about DynamicBanScores: https://github.com/btcsuite/btcd/commit/3e8182cd7778413f3bc8ca498db73ac90fe0fd65