### PR TITLE
database/ffldb/disk_posix.go:

### DIFF
--- a/database/ffldb/disk_posix.go
+++ b/database/ffldb/disk_posix.go
@@ -22,5 +22,5 @@ func getAvailableDiskSpace(path string) (uint64, error) {
 
 	syscall.Statfs(wd, &stat)
 
-	return stat.Bavail * uint64(stat.Bsize), nil
+	return uint64(stat.Bavail) * uint64(stat.Bsize), nil
 }


### PR DESCRIPTION
  - Corrected failue "invalid operation: stat.Bavail * uint64(stat.Bsize) (mismatched types int64 and uint64)"
    during build of pktd on FreeBSD-13.0-STABLE amd64