### PR TITLE
Fixed wallet db absolute path handling and build script on Windows

### DIFF
--- a/contrib/build/build.go
+++ b/contrib/build/build.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"runtime"
 )
 
 // generic stuff
@@ -66,7 +67,7 @@ type config struct {
 }
 
 func build(name string, pkg string, conf *config) {
-	if os.Getenv("GOOS") == "windows" {
+	if runtime.GOOS == "windows" {
 		name = name + ".exe"
 	}
 	fmt.Printf("Building %s\n", name)

--- a/do.cmd
+++ b/do.cmd
@@ -1,0 +1,1 @@
+go run ./contrib/build/build.go %*

--- a/neutrino/blockmanager.go
+++ b/neutrino/blockmanager.go
@@ -766,6 +766,7 @@ func (b *blockManager) getUncheckpointedCFHeaders(
 	for peer, msg := range headers {
 		if msg.PrevFilterHeader != *filterTip {
 			sp := b.server.PeerByAddr(peer)
+			log.Infof("Peer [%s] served invalid filter header", sp.Addr())
 			sp.addBanScore(0, 33, "InvalidFilterHeader")
 			delete(headers, peer)
 		}
@@ -794,6 +795,7 @@ func (b *blockManager) getUncheckpointedCFHeaders(
 
 			for _, peer := range badPeers {
 				sp := b.server.PeerByAddr(peer)
+				log.Infof("Peer [%s] served invalid filter header", sp.Addr())
 				sp.addBanScore(0, 33, "InvalidFilterHeader")
 				delete(headers, peer)
 			}
@@ -1336,6 +1338,7 @@ func (b *blockManager) resolveConflict(
 
 			for _, peer := range badPeers {
 				sp := b.server.PeerByAddr(peer)
+				log.Infof("Peer [%s] served invalid filter header", sp.Addr())
 				sp.addBanScore(0, 33, "InvalidFilterHeader")
 				delete(headers, peer)
 				delete(checkpoints, peer)

--- a/pktwallet/wallet/loader.go
+++ b/pktwallet/wallet/loader.go
@@ -102,13 +102,10 @@ func (l *Loader) RunAfterLoad(fn func(*Wallet)) {
 }
 
 func WalletDbPath(netDir, walletName string) string {
-	if strings.HasSuffix(walletName, ".db") {
-		if strings.HasPrefix(walletName, "/") {
-			// absolute path
-			return walletName
-		} else {
-			return filepath.Join(netDir, walletName)
-		}
+	if filepath.IsAbs(walletName) {
+		return walletName
+	} else if strings.HasSuffix(walletName, ".db") {
+		return filepath.Join(netDir, walletName)
 	} else {
 		return filepath.Join(netDir, fmt.Sprintf("wallet_%s.db", walletName))
 	}


### PR DESCRIPTION
This PR contains two patches:
- The first one fixes detection of an absolute path for a wallet database file on Windows, and allows to open database files regardless of the file extension when an absolute path is specified
- The second patch fixes Windows OS detection in the build script to add the correct extension to the generated binary filenames and adds a convenience script to build the project