### PR TITLE
fix broken TestLightningWallet() tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ _testmain.go
 
 *.rpm
 *.deb
+
+#testing output files
+*.out

--- a/lnd/lnwallet/channel.go
+++ b/lnd/lnwallet/channel.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkt-cash/pktd/wire"
 )
 
-var zeroHash chainhash.Hash
+//var zeroHash chainhash.Hash
 
 var (
 	Err = er.NewErrorType("lnd.lnwallet")


### PR DESCRIPTION
The following things were added/changed:

. added the extension .out to .gitignore, which is the extension I'm using for the output of tests execution;
. added a comment to channel.go because the variable is never used;
. debugging the code I realized that the test was failing due to a 30 satochi's difference between the amount subtracted from the wallet and the fee charged from it. It fixed the test but, I still need to better understand how the 2500 SatPerKWeight fee rate is evaluated to 14420 satochi's;
. I kept the debug traces used during the debugging of the test code;
. added a enable attribute to walletTestCase to disable some of the tests in a way to clear the warning messages about  test functions never invoked;
. change in runTests() function to take the enable attribute value into account to run only those test cases that are enabled.
