### PR TITLE
add pktdir param to pld

### DIFF
--- a/lnd/cmd/lncli/profile.go
+++ b/lnd/cmd/lncli/profile.go
@@ -27,6 +27,7 @@ type profileEntry struct {
 	Name        string       `json:"name"`
 	RPCServer   string       `json:"rpcserver"`
 	LndDir      string       `json:"lnddir"`
+	PktDir      string       `json:"pktdir"`
 	Chain       string       `json:"chain"`
 	Network     string       `json:"network"`
 	NoMacaroons bool         `json:"no-macaroons,omitempty"`
@@ -115,7 +116,7 @@ func profileFromContext(ctx *cli.Context, store, skipMacaroons bool) (
 
 	// Parse the paths of the cert and macaroon. This will validate the
 	// chain and network value as well.
-	tlsCertPath, macPath, err := extractPathArgs(ctx)
+	tlsCertPath, macPath, pktDir, err := extractPathArgs(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -135,6 +136,7 @@ func profileFromContext(ctx *cli.Context, store, skipMacaroons bool) (
 	entry := &profileEntry{
 		RPCServer:   ctx.GlobalString("rpcserver"),
 		LndDir:      lncfg.CleanAndExpandPath(ctx.GlobalString("lnddir")),
+		PktDir:      pktDir,
 		Chain:       ctx.GlobalString("chain"),
 		Network:     ctx.GlobalString("network"),
 		NoMacaroons: ctx.GlobalBool("no-macaroons"),

--- a/lnd/config.go
+++ b/lnd/config.go
@@ -181,6 +181,7 @@ type Config struct {
 	ShowVersion bool `short:"V" long:"version" description:"Display version information and exit"`
 
 	LndDir       string `long:"lnddir" description:"The base directory that contains lnd's data, logs, configuration file, etc."`
+	PktDir       string `long:"pktdir" description:"The base directory that contains pktwallet's data etc."`
 	ConfigFile   string `short:"C" long:"configfile" description:"Path to configuration file"`
 	DataDir      string `short:"b" long:"datadir" description:"The directory to store lnd's data within"`
 	WalletFile   string `long:"wallet" description:"Wallet file name or path, if a simple word such as 'personal' then pktwallet will look for wallet_personal.db, if prefixed with a / then pktwallet will consider it an absolute path. (default: wallet.db)"`
@@ -337,6 +338,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		LndDir:            DefaultLndDir,
+		PktDir:            defaultPktWalletDir,
 		ConfigFile:        DefaultConfigFile,
 		DataDir:           defaultDataDir,
 		WalletFile:        defaultWalletFile,
@@ -610,6 +612,7 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, er.R) {
 	// to directories and files are cleaned and expanded before attempting
 	// to use them later on.
 	cfg.DataDir = CleanAndExpandPath(cfg.DataDir)
+	cfg.PktDir = CleanAndExpandPath(cfg.PktDir)
 	cfg.LetsEncryptDir = CleanAndExpandPath(cfg.LetsEncryptDir)
 	cfg.AdminMacPath = CleanAndExpandPath(cfg.AdminMacPath)
 	cfg.ReadMacPath = CleanAndExpandPath(cfg.ReadMacPath)
@@ -628,6 +631,7 @@ func ValidateConfig(cfg Config, usageMessage string) (*Config, er.R) {
 	// for files that point to outside of the lnddir.
 	dirs := []string{
 		lndDir, cfg.DataDir,
+		cfg.PktDir,
 		cfg.LetsEncryptDir, cfg.Watchtower.TowerDir,
 		filepath.Dir(cfg.AdminMacPath), filepath.Dir(cfg.ReadMacPath),
 		filepath.Dir(cfg.InvoiceMacPath),


### PR DESCRIPTION
added a --pktdir argument for pld to pass where the pkt folder is, in order to support android and ios where default home paths are inaccessible.