### PR TITLE
fix bug missing data/chain for temp backup file

### DIFF
--- a/lnd/chanbackup/backupfile.go
+++ b/lnd/chanbackup/backupfile.go
@@ -57,6 +57,15 @@ func NewMultiFile(fileName string) *MultiFile {
 	// We'll our temporary backup file in the very same directory as the
 	// main backup file.
 	backupFileDir := filepath.Dir(fileName)
+	//Check if folder exists
+	_, err := os.Stat(backupFileDir)
+	if os.IsNotExist(err) {
+		if err := os.MkdirAll(backupFileDir, 0700); err != nil {
+			log.Errorf("unable to create folder %s", backupFileDir)
+			return nil
+		}
+	}
+
 	tempFileName := filepath.Join(
 		backupFileDir, DefaultTempBackupFileName,
 	)


### PR DESCRIPTION
fix bug where pld was trying to create a temp back up file in lnd/data/chain folder. This folder was being created when neutrino was being initialized. Now that we moved neutrino the folder did not exist and there was no check when trying to create the temp file.