### PR TITLE
Fix broken lnd/walletunlocker tests

### DIFF
--- a/lnd/walletunlocker/service.go
+++ b/lnd/walletunlocker/service.go
@@ -159,7 +159,8 @@ func New(chainDir string, params *chaincfg.Params, noFreelistSync bool,
 
 func (u *UnlockerService) GenSeed(_ context.Context,
 	in *lnrpc.GenSeedRequest) (*lnrpc.GenSeedResponse, error) {
-	res, err := u.GenSeed0(context.TODO(), in)
+	//	TODO: should replace the nil context by context.TODO()
+	res, err := u.GenSeed0(nil, in)
 	return res, er.Native(err)
 }
 
@@ -294,7 +295,6 @@ func (u *UnlockerService) InitWallet0(ctx context.Context,
 		netDir = u.walletPath
 	}
 	loader := wallet.NewLoader(u.netParams, netDir, u.walletFile, u.noFreelistSync, uint32(recoveryWindow))
-	log.Debugf(">>>>> 2.5. wallet path: %s/%s", netDir, u.walletFile)
 
 	walletExists, err := loader.WalletExists()
 	if err != nil {
@@ -308,7 +308,6 @@ func (u *UnlockerService) InitWallet0(ctx context.Context,
 	}
 
 	mnemonic := strings.Join(in.CipherSeedMnemonic, " ")
-	log.Debugf(">>>>> 3. mnemonic: %s", mnemonic)
 	seedEnc, err := seedwords.SeedFromWords(mnemonic)
 	if err != nil {
 		return nil, err

--- a/lnd/walletunlocker/service.go
+++ b/lnd/walletunlocker/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/pkt-cash/pktd/btcutil/er"
@@ -158,7 +159,7 @@ func New(chainDir string, params *chaincfg.Params, noFreelistSync bool,
 
 func (u *UnlockerService) GenSeed(_ context.Context,
 	in *lnrpc.GenSeedRequest) (*lnrpc.GenSeedResponse, error) {
-	res, err := u.GenSeed0(nil, in)
+	res, err := u.GenSeed0(context.TODO(), in)
 	return res, er.Native(err)
 }
 
@@ -647,7 +648,7 @@ func (u *UnlockerService) CreateWallet(ctx context.Context, req *lnrpc.CreateWal
 		log.Infof("Using provided cipher seed mnemonic.")
 		//Check Seed Mnemonic
 		if len(req.CipherSeedMnemonic) != 15 {
-			return response, er.Native(er.New("wrong cipher seed mnemonic length: got " + string(len(req.CipherSeedMnemonic)) + " words, expecting 15 words"))
+			return response, er.Native(er.New("wrong cipher seed mnemonic length: got " + strconv.Itoa(len(req.CipherSeedMnemonic)) + " words, expecting 15 words"))
 		}
 		cipherSeedString := strings.Join(cipherSeed, " ")
 		seedEnc, err := seedwords.SeedFromWords(cipherSeedString)

--- a/lnd/walletunlocker/service.go
+++ b/lnd/walletunlocker/service.go
@@ -294,6 +294,7 @@ func (u *UnlockerService) InitWallet0(ctx context.Context,
 		netDir = u.walletPath
 	}
 	loader := wallet.NewLoader(u.netParams, netDir, u.walletFile, u.noFreelistSync, uint32(recoveryWindow))
+	log.Debugf(">>>>> 2.5. wallet path: %s/%s", netDir, u.walletFile)
 
 	walletExists, err := loader.WalletExists()
 	if err != nil {
@@ -307,6 +308,7 @@ func (u *UnlockerService) InitWallet0(ctx context.Context,
 	}
 
 	mnemonic := strings.Join(in.CipherSeedMnemonic, " ")
+	log.Debugf(">>>>> 3. mnemonic: %s", mnemonic)
 	seedEnc, err := seedwords.SeedFromWords(mnemonic)
 	if err != nil {
 		return nil, err

--- a/pktwallet/wallet/seedwords/seed.go
+++ b/pktwallet/wallet/seedwords/seed.go
@@ -211,6 +211,11 @@ func (s *Seed) Birthday() time.Time {
 	return s.seedBin.getBday()
 }
 
+// Provide the seed version number
+func (s *Seed) Version() byte {
+	return s.seedBin.getVer()
+}
+
 // Bytes returns the secret seed, 19 bytes long including the birthday bytes
 // which provide a small amount of additional entropy.
 func (s *Seed) Bytes() []byte {


### PR DESCRIPTION
The following things were added/changed:

. compilation errors fixed in the service_test.go;
. refactory of all test cases to comply with the replacement of aezeed cipher to seedwords package;
. elimination of a test case that doesn't make sense anymore due to the lack of support to entropy in the seedwords package;
. method ( seedwords.Seed ) Version() added to allow a test in lnd/walletunlocker;
. added a test case to seed_test.go to make sure cipher and decipher functions are reversible;
. I kept some debug traces used during the debugging of the test code;
