### PR TITLE
check privpass when unlocking wallet

### DIFF
--- a/lnd/walletunlocker/service.go
+++ b/lnd/walletunlocker/service.go
@@ -398,7 +398,13 @@ func (u *UnlockerService) UnlockWallet0(ctx context.Context,
 		// password was incorrect.
 		return nil, err
 	}
-
+	//Also test against private password
+	err = unlockedWallet.Unlock(privpassword, nil)
+	if err != nil {
+		//unload wallet so future unlock calls can be processed
+		loader.UnloadWallet()
+		return nil, err
+	}
 	// We successfully opened the wallet and pass the instance back to
 	// avoid it needing to be unlocked again.
 	walletUnlockMsg := &WalletUnlockMsg{


### PR DESCRIPTION
try unlocking the address manager of the wallet when unlocking the wallet thus testing the private password when trying to open the wallet. So if the private password is wrong we will return the error and unload the wallet and not let pld crash. User then can retry unlocking the wallet since the service continues to run.