### PR TITLE
Fix broken lnd + lnd/lntest tests

### DIFF
--- a/lnd/lntest/harness.go
+++ b/lnd/lntest/harness.go
@@ -465,7 +465,7 @@ func (n *NetworkHarness) EnsureConnected(ctx context.Context, a, b *HarnessNode)
 
 		req := &lnrpc.ConnectPeerRequest{
 			Addr: &lnrpc.LightningAddress{
-				Pubkey: bInfo.IdentityPubkey,
+				Pubkey: string(bInfo.IdentityPubkey),
 				Host:   b.Cfg.P2PAddr(),
 			},
 		}
@@ -537,7 +537,7 @@ func (n *NetworkHarness) EnsureConnected(ctx context.Context, a, b *HarnessNode)
 		}
 
 		for _, peer := range resp.Peers {
-			if peer.PubKey == a.PubKeyStr {
+			if string(peer.PubKey) == a.PubKeyStr {
 				return true
 			}
 		}
@@ -569,7 +569,7 @@ func (n *NetworkHarness) ConnectNodes(ctx context.Context, a, b *HarnessNode) er
 
 	req := &lnrpc.ConnectPeerRequest{
 		Addr: &lnrpc.LightningAddress{
-			Pubkey: bobInfo.IdentityPubkey,
+			Pubkey: string(bobInfo.IdentityPubkey),
 			Host:   b.Cfg.P2PAddr(),
 		},
 	}
@@ -588,7 +588,7 @@ func (n *NetworkHarness) ConnectNodes(ctx context.Context, a, b *HarnessNode) er
 		}
 
 		for _, peer := range resp.Peers {
-			if peer.PubKey == b.PubKeyStr {
+			if string(peer.PubKey) == b.PubKeyStr {
 				return true
 			}
 		}
@@ -611,7 +611,7 @@ func (n *NetworkHarness) DisconnectNodes(ctx context.Context, a, b *HarnessNode)
 	}
 
 	req := &lnrpc.DisconnectPeerRequest{
-		PubKey: bobInfo.IdentityPubkey,
+		PubKey: string(bobInfo.IdentityPubkey),
 	}
 
 	if _, errr := a.DisconnectPeer(ctx, req); errr != nil {
@@ -1076,7 +1076,7 @@ func (n *NetworkHarness) CloseChannel(ctx context.Context,
 		if err != nil {
 			return nil, nil, err
 		}
-		receivingNode, err := n.LookUpNodeByPub(targetChan.RemotePubkey)
+		receivingNode, err := n.LookUpNodeByPub(string(targetChan.RemotePubkey))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/lnd/lntest/node.go
+++ b/lnd/lntest/node.go
@@ -824,9 +824,9 @@ func (hn *HarnessNode) FetchNodeInfo() er.R {
 		return er.E(errr)
 	}
 
-	hn.PubKeyStr = info.IdentityPubkey
+	hn.PubKeyStr = string(info.IdentityPubkey)
 
-	pubkey, err := util.DecodeHex(info.IdentityPubkey)
+	pubkey, err := util.DecodeHex(string(info.IdentityPubkey))
 	if err != nil {
 		return err
 	}

--- a/lnd/server_test.go
+++ b/lnd/server_test.go
@@ -1,20 +1,16 @@
+//go:build !rpctest
 // +build !rpctest
 
 package lnd
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/pem"
-	"io/ioutil"
 	"math/big"
 	"net"
-	"os"
 	"testing"
 	"time"
 )
@@ -60,6 +56,9 @@ func TestParseHexColor(t *testing.T) {
 // TestTLSAutoRegeneration creates an expired TLS certificate, to test that a
 // new TLS certificate pair is regenerated when the old pair expires. This is
 // necessary because the pair expires after a little over a year.
+/*
+//	this test case doesn't make sense anymore since the function getTLSConfig() was removed
+//	from the codebase and maybe TLS support will be removed from the codebase too
 func TestTLSAutoRegeneration(t *testing.T) {
 	tempDirPath, errr := ioutil.TempDir("", ".testLnd")
 	if errr != nil {
@@ -143,6 +142,7 @@ func TestTLSAutoRegeneration(t *testing.T) {
 		t.Fatalf("New certificate expiration is too old")
 	}
 }
+*/
 
 // genExpiredCertPair generates an expired key/cert pair to test that expired
 // certificates are being regenerated correctly.


### PR DESCRIPTION
The following things were added/changed/fixed:

. elimination of TestTLSAutoRegeneration() test case from  lnd/server_test.go whose functionality (getTLSConfig(cfg)) was wiped out from the codebase;
. compilation errors fixed in the following tests: lnd/lntest/harness.go and lnd/lntest/node.go;
