### PR TITLE
Removed broken DNS seed nodes

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -596,9 +596,7 @@ var PktMainNetParams = Params{
 	DefaultPort: "64764",
 	DNSSeeds: []DNSSeed{
 		{"seed.cjd.li", false},
-		{"seed.anode.co", false},
 		{"pktdseed.pkt.world", false},
-		{"seed.srizbi.com", false},
 	},
 
 	// Chain parameters


### PR DESCRIPTION
Both removed addresses point at a fixed set of IP addresses which were not providing pkt peer services