### PR TITLE
Force pld and pldctl to not use macaroons

### DIFF
--- a/lnd/cmd/lncli/main.go
+++ b/lnd/cmd/lncli/main.go
@@ -380,6 +380,20 @@ func main() {
 	app.Commands = append(app.Commands, watchtowerCommands()...)
 	app.Commands = append(app.Commands, wtclientCommands()...)
 
+	//	we want to disable the use of macaroons so, force that it's turned off
+	const noMacaroonsArg string = "--no-macaroons"
+	var noMacaroons bool = false
+
+	for _, arg := range os.Args {
+		if arg == noMacaroonsArg {
+			noMacaroons = true
+			break
+		}
+	}
+	if !noMacaroons {
+		os.Args = append(os.Args, noMacaroonsArg)
+	}
+
 	if err := app.Run(os.Args); err != nil {
 		fatal(er.E(err))
 	}

--- a/lnd/cmd/lnd/main.go
+++ b/lnd/cmd/lnd/main.go
@@ -35,6 +35,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	//	we want to disable the use of macaroons so, force that it's turned off
+	loadedConfig.NoMacaroons = true
+
 	// Call the "real" main in a nested manner so the defers will properly
 	// be executed in the case of a graceful shutdown.
 	if err := lnd.Main(

--- a/lnd/lnd.go
+++ b/lnd/lnd.go
@@ -403,6 +403,10 @@ func Main(cfg *Config, lisCfg ListenerCfg, shutdownChan <-chan struct{}) er.R {
 	}
 
 	var macaroonService *macaroons.Service
+
+	//	just to helps us to make sure that macaroons are turned off
+	log.Infof("No-Macaroons option: %t", cfg.NoMacaroons)
+
 	if !cfg.NoMacaroons {
 		// Create the macaroon authentication/authorization service.
 		macaroonService, err = macaroons.NewService(

--- a/lnd/lnwallet/interface_test.go
+++ b/lnd/lnwallet/interface_test.go
@@ -2036,6 +2036,9 @@ func testSignOutputUsingTweaks(r *rpctest.Harness,
 			t.Fatalf("unable to generate script: %v", err)
 		}
 
+		//	let's wait a bit for the wallet's funding transactions be confirmed !
+		time.Sleep(10 * time.Second)
+
 		// With the script fully assembled, instruct the wallet to fund
 		// the output with a newly created transaction.
 		newOutput := &wire.TxOut{

--- a/test/createWallet.pl
+++ b/test/createWallet.pl
@@ -1,0 +1,56 @@
+#!  /usr/bin/perl -w
+
+################################################################################
+#   requires the installation of cpan, and after needs to run the following:
+#   $ echo "install Expect" | cpan
+################################################################################
+
+use strict;
+use Expect;
+
+my  $PLDCTL='./bin/pldctl';
+my  $PLDCTL_ARGS='create';
+my  $WALLET_PASSWORD='w4ll3tP@sswd';
+my  $SEED_PASSPHRASE='s3edP@ssphr4z';
+
+#   check cli arguments
+my  $VERBOSE = '';
+
+if( $#ARGV + 1 == 1 ) {
+    $VERBOSE = $ARGV[ 0 ];
+}
+
+#   open a pipe to interact with pldctl
+my  $pldctl = Expect->new;
+my  $inputLine;
+
+$pldctl->raw_pty( 1 );
+$pldctl->spawn( qq/$PLDCTL $PLDCTL_ARGS/ )
+    or die qq/Failed to open pipe to $PLDCTL: $!/;
+
+if( $VERBOSE eq '--verbose' ) {
+    $pldctl->exp_internal( 1 );
+}
+
+#   wait pldctl ask for wallet password, and the send it
+$pldctl->expect( 10, 'Input wallet password: ' );
+$pldctl->send( qq/$WALLET_PASSWORD\n/ );
+
+#   wait pldctl ask for wallet password confirmation, and the send it
+$pldctl->expect( 10, 'Confirm password: ' );
+$pldctl->send( qq/$WALLET_PASSWORD\n/ );
+
+#   wait pldctl ask for seed existence, and the send it
+$pldctl->expect( 10, 'Do you have an existing Pktwallet seed you want to use? (Enter y\/n): ' );
+$pldctl->send( qq/n\n/ );
+
+#   wait pldctl ask for cipher seed passphrase, and the send it
+$pldctl->expect( 10, 'Input your passphrase if you wish to encrypt it (or press enter to proceed without a cipher seed passphrase): ' );
+$pldctl->send( qq/$SEED_PASSPHRASE\n/ );
+
+#   wait pldctl ask for cipher seed passphrase confirmation, and the send it
+$pldctl->expect( 10, 'Confirm password: ' );
+$pldctl->send( qq/$SEED_PASSPHRASE\n/ );
+
+#   wait pldctl shows a successful message
+$pldctl->expect( 10, 'pld successfully initialized!' );

--- a/test/lnd_test.sh
+++ b/test/lnd_test.sh
@@ -1,0 +1,85 @@
+#!  /usr/bin/bash
+
+################################################################################
+#   requires the installation of jq
+################################################################################
+
+export  PKT_HOME="$( pwd )"
+export  PLD="${PKT_HOME}/bin/pld"
+#export  PLD_OPTIONS="--no-macaroons"
+export  PLD_OPTIONS=""
+export  PLD_OUTPUT_FILE="./pld.out"
+export  PLDCTL="${PKT_HOME}/bin/pldctl"
+#export  PLDCTL_OPTIONS="--no-macaroons"
+export  PLDCTL_OPTIONS=""
+export  PLDCTL_ERRORS_FILE="./pldctl.err"
+
+#   use pldctl to execute a command
+executeCommand() {
+    local COMMAND="${1}"
+    local ARGUMENTS="${2}"
+
+    OUTPUT=$( ${PLDCTL} ${PLDCTL_OPTIONS} ${COMMAND} ${ARGUMENTS} 2>> ${PLDCTL_ERRORS_FILE} )
+    if [ $? == 0 ]
+    then
+        echo ">>> ${COMMAND} ${ARGUMENTS}: command successfully executed"
+    else
+        echo "error: fail attempting to run command \"${COMMAND} ${ARGUMENTS}\": $?"
+    fi
+}
+
+#   splash screen
+echo ">>>>> Testing pld and pldctl"
+echo
+
+#   clean things up by removing previous wallet
+rm -rf ~/.lncli ~/.pki ~/.pktd ~/.pktwallet
+rm -rf ${PLD_OUTPUT_FILE}
+rm -rf ${PLDCTL_ERRORS_FILE}
+
+#   run pld deamon in background
+${PLD} ${PLD_OPTIONS} > ${PLD_OUTPUT_FILE} &
+
+export  PLD_PID=$!
+
+echo ">>> ${PLD} daemon up and running: PID: ${PLD_PID}"
+
+sleep 5s
+
+#   create a wallet
+OUTPUT=$( perl -w ./test/createWallet.pl )
+
+if [ -z "$( echo ${OUTPUT} | grep 'pld successfully initialized!' )" ]
+then
+    kill ${PLD_PID}
+    exit "error: fail attempting to run command create wallet"
+fi
+
+echo ">>> create: command executed"
+
+#   test commands to get info about the running pld daemon
+executeCommand 'getinfo'
+executeCommand 'getrecoveryinfo'
+executeCommand 'version'
+
+#   test commands to deal with profile
+executeCommand 'profile' 'add pld_test'
+executeCommand 'profile' 'list'
+executeCommand 'profile' 'setdefault pld_test'
+executeCommand 'profile' 'remove pld_test'
+
+#   test commands to deal with wallet
+executeCommand 'newaddress' 'p2wkh'
+
+#   show any eventual error during command execution
+if [ -f "${PLDCTL_ERRORS_FILE}" ]
+then
+    echo ">>> errors executing some command "
+    echo "+++++++++++++++"
+    cat ${PLDCTL_ERRORS_FILE}
+fi
+
+#   shutdown pld deamon
+executeCommand 'stop'
+
+kill ${PLD_PID} 2> /dev/null


### PR DESCRIPTION
The following things were added/changed/fixed:

. ignoring the CLI flags and forcing the option --no-macaroons on both pld and pltctl main fuctions;
. added a delay in the testSignOutputUsingTweaks() test case, as it was failing due to the payment transaction was starting before the funding transactions were confirmed;
. added two script to automate integration tests for pld and pldctl programs;
. I kept some debug traces used during the debugging of the test code;