### PR TITLE
Resync after ImportPrivKey and NeutrinoDB corruption fixes

### DIFF
--- a/neutrino/headerfs/index.go
+++ b/neutrino/headerfs/index.go
@@ -602,7 +602,7 @@ func (h *NeutrinoDBStore) addBlockHeaders(tx walletdb.ReadWriteTx, batch headerW
 	for _, header := range batch {
 		if !isGenesis && header.Height != tip.Height+1 {
 			log.Warnf("Unable to add block header at height %v because tip is %v", header.Height, tip.Height)
-			break
+			return er.Errorf("Unable to add block header at height %v because tip is %v", header.Height, tip.Height)
 		}
 		he := headerEntry{blockHeader: header.Header.blockHeader, filterHeader: nil}
 		value := he.Bytes()

--- a/neutrino/headerfs/store.go
+++ b/neutrino/headerfs/store.go
@@ -119,6 +119,9 @@ func (h *NeutrinoDBStore) RollbackLastBlock(tx walletdb.ReadWriteTx) (*RollbackH
 		result.FilterHeader = nil
 		return &result, err
 	} else {
+		result.BlockHeader = &waddrmgr.BlockStamp{}
+		result.FilterHeader = &chainhash.Hash{}
+
 		result.BlockHeader.Hash = prev.Header.blockHeader.BlockHash()
 		result.BlockHeader.Height = int32(prev.Height)
 		result.FilterHeader = prev.Header.filterHeader

--- a/neutrino/headerfs/store_test.go
+++ b/neutrino/headerfs/store_test.go
@@ -149,40 +149,32 @@ func TestBlockHeaderStoreOperations(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unable to rollback chain: %v", err)
 		}
-		//if secondToLastHeader.Height != uint32(blockStamp.Height) {
-		//	t.Fatalf("chain tip doesn't match: expected %v, got %v",
-		//	secondToLastHeader.Height, blockStamp.Height)
-		//}
-		//	TODO: the four tests below were commented because I belive they are based on a false
-		//		assumption the method bhs.RollbackLastBlock() delete blocks in the same order
-		//		that they were add (and not necessarily inserted keeping the same order)
+
 		if secondToLastHeader.Height != uint32(blockStamp.BlockHeader.Height) {
-			//			t.Fatalf("chain tip doesn't match: expected %v, got %v",
-			//				secondToLastHeader.Height, blockStamp.BlockHeader.Height)
+			t.Fatalf("chain tip doesn't match: expected %v, got %v",
+				secondToLastHeader.Height, blockStamp.BlockHeader.Height)
 		}
+
 		headerHash := secondToLastHeader.BlockHash()
-		//if !bytes.Equal(headerHash[:], blockStamp.Hash[:]) {
-		//	t.Fatalf("header hashes don't match: expected %v, got %v",
-		//		headerHash, blockStamp.Hash)
-		//}
 		if !bytes.Equal(headerHash[:], blockStamp.BlockHeader.Hash[:]) {
-			//			t.Fatalf("header hashes don't match: expected %v, got %v",
-			//				headerHash, blockStamp.BlockHeader.Hash)
+			t.Fatalf("header hashes don't match: expected %v, got %v",
+				headerHash, blockStamp.BlockHeader.Hash)
 		}
-		//tipHeader, tipHeight, err = bhs.ChainTip1(tx)
+
 		tipHeader, tipHeight, err = bhs.BlockChainTip1(tx)
 		if err != nil {
 			t.Fatalf("unable to fetch chain tip")
 		}
 		if !reflect.DeepEqual(secondToLastHeader.BlockHeader, tipHeader) {
-			//			t.Fatalf("tip height headers don't match up: "+
-			//				"expected %v, got %v", spew.Sdump(secondToLastHeader),
-			//				spew.Sdump(tipHeader))
+			t.Fatalf("tip height headers don't match up: "+
+				"expected %v, got %v", spew.Sdump(secondToLastHeader),
+				spew.Sdump(tipHeader))
 		}
 		if tipHeight != secondToLastHeader.Height {
-			//			t.Fatalf("chain tip doesn't match: expected %v, got %v",
-			//				secondToLastHeader.Height, tipHeight)
+			t.Fatalf("chain tip doesn't match: expected %v, got %v",
+				secondToLastHeader.Height, tipHeight)
 		}
+
 		return nil
 	})
 }

--- a/pktwallet/wallet/wallet.go
+++ b/pktwallet/wallet/wallet.go
@@ -830,6 +830,10 @@ out:
 // be locked if the passphrase is incorrect or any other error occurs during the
 // unlock.
 func (w *Wallet) Unlock(passphrase []byte, lock <-chan time.Time) er.R {
+	log.Infof("Unlock() [1]")
+	err_ := er.Errorf("Forged error to get the stack trace")
+	log.Infof("Unlock() [1] stack trace: %v", err_)
+
 	err := make(chan er.R, 1)
 	w.unlockRequests <- unlockRequest{
 		passphrase: passphrase,

--- a/test/lnd_test.sh
+++ b/test/lnd_test.sh
@@ -411,7 +411,7 @@ then
     cat ${PLDCTL_ERRORS_FILE}
 fi
 
-rm -rf ${PLDCTL_ERRORS_FILE}
-
 #   stop pld daemon
 stopPldDeamon
+
+rm -rf ${PLDCTL_ERRORS_FILE}


### PR DESCRIPTION
The following were added/changed/fixed:

. start resync from block 1 instead of genesis after importing a private key;
. fix bug that was corrupting NeutrinoDB;
. fix segmentation fault on RollbackLastBlock();
. fix some tests regarding the changes in RollbackLastBlock();
. I kept some debug traces used during the debugging of the test code;
