### PR TITLE
remove unnecessary exit when stopping server

### DIFF
--- a/lnd/lnrpc/routerrpc/router_server.go
+++ b/lnd/lnrpc/routerrpc/router_server.go
@@ -190,10 +190,6 @@ func New(cfg *Config) (*Server, lnrpc.MacaroonPerms, er.R) {
 //
 // NOTE: This is part of the lnrpc.SubServer interface.
 func (s *Server) Start() er.R {
-	if atomic.AddInt32(&s.started, 1) != 1 {
-		return nil
-	}
-
 	return nil
 }
 
@@ -201,9 +197,6 @@ func (s *Server) Start() er.R {
 //
 // NOTE: This is part of the lnrpc.SubServer interface.
 func (s *Server) Stop() er.R {
-
-	os.Exit(0)
-
 	return nil
 }
 


### PR DESCRIPTION
Remove unnecessary os.exit when stopping router server.