### PR TITLE
Moving help meta info to proto files

### DIFF
--- a/lnd/lnrpc/gen_protos.sh
+++ b/lnd/lnrpc/gen_protos.sh
@@ -44,15 +44,6 @@ for file in $PROTOS; do
     --doc_opt="json,${file}.doc.json" \
     "${file}"
 
-  #protoc -I/usr/local/include -I. \
-  #  --go_out=. \
-  #  --go_opt='paths=source_relative' \
-  #  --go-grpc_out=. \
-  #  --go-grpc_opt=paths=source_relative,require_unimplemented_servers=false \
-  #  --doc_out=. \
-  #  --doc_opt="json,${file}.doc.json" \
-  #  "${file}"
-
   if [ $? -ne 0 ]
   then
     echo "${0}: fail attempting to generate the protos for file ${file}"

--- a/lnd/lnrpc/metaservice.proto
+++ b/lnd/lnrpc/metaservice.proto
@@ -8,20 +8,39 @@ import "rpc.proto";
 option go_package = "github.com/pkt-cash/pktd/lnd/lnrpc";
 
 service MetaService {
+    /*
+    $pld.category: `Meta`
+    $pld.short_description: `Returns basic information related to the active daemon`
+
+    GetInfo returns general information concerning the lightning node including
+    it's identity pubkey, alias, the chains it is connected to, and information
+    concerning the number of open+pending channels.
+    */
     rpc GetInfo2 (GetInfo2Request) returns (GetInfo2Response);
 
-    /* lncli: `changepassword`
+    /*
+    $pld.category: `Wallet`
+    $pld.short_description: `Change an encrypted wallet's password at startup`
+
     ChangePassword changes the password of the encrypted wallet. This will
     automatically unlock the wallet database if successful.
     */
     rpc ChangePassword (ChangePasswordRequest) returns (ChangePasswordResponse);
 
-    /* lncli: `checkPassword`
+    /*
+    $pld.category: `Wallet`
+    $pld.short_description: `Check the wallet's password`
+
     CheckPassword verify that the password in the request is valid for the wallet.
     */
     rpc CheckPassword (CheckPasswordRequest) returns (CheckPasswordResponse);
 
-    /*  Force a pld crash (for debug purposes) */
+    /*
+    $pld.category: `Meta`
+    $pld.short_description: `Force pld to crash (for debugging purposes)`
+
+    Force a pld crash (for debugging purposes)
+    */
     rpc ForceCrash (CrashRequest) returns (CrashResponse);
 }
 

--- a/lnd/lnrpc/metaservice.proto.doc.json
+++ b/lnd/lnrpc/metaservice.proto.doc.json
@@ -233,7 +233,7 @@
           "methods": [
             {
               "name": "GetInfo2",
-              "description": "",
+              "description": "$pld.category: `Meta`\n$pld.short_description: `Returns basic information related to the active daemon`\n\nGetInfo returns general information concerning the lightning node including\nit's identity pubkey, alias, the chains it is connected to, and information\nconcerning the number of open+pending channels.",
               "requestType": "GetInfo2Request",
               "requestLongType": "GetInfo2Request",
               "requestFullType": "lnrpc.GetInfo2Request",
@@ -245,7 +245,7 @@
             },
             {
               "name": "ChangePassword",
-              "description": "lncli: `changepassword`\nChangePassword changes the password of the encrypted wallet. This will\nautomatically unlock the wallet database if successful.",
+              "description": "$pld.category: `Wallet`\n$pld.short_description: `Change an encrypted wallet's password at startup`\n\nChangePassword changes the password of the encrypted wallet. This will\nautomatically unlock the wallet database if successful.",
               "requestType": "ChangePasswordRequest",
               "requestLongType": "ChangePasswordRequest",
               "requestFullType": "lnrpc.ChangePasswordRequest",
@@ -257,7 +257,7 @@
             },
             {
               "name": "CheckPassword",
-              "description": "lncli: `checkPassword`\nCheckPassword verify that the password in the request is valid for the wallet.",
+              "description": "$pld.category: `Wallet`\n$pld.short_description: `Check the wallet's password`\n\nCheckPassword verify that the password in the request is valid for the wallet.",
               "requestType": "CheckPasswordRequest",
               "requestLongType": "CheckPasswordRequest",
               "requestFullType": "lnrpc.CheckPasswordRequest",
@@ -269,7 +269,7 @@
             },
             {
               "name": "ForceCrash",
-              "description": "Force a pld crash (for debug purposes)",
+              "description": "$pld.category: `Meta`\n$pld.short_description: `Force pld to crash (for debugging purposes)`\n\nForce a pld crash (for debugging purposes)",
               "requestType": "CrashRequest",
               "requestLongType": "CrashRequest",
               "requestFullType": "lnrpc.CrashRequest",

--- a/lnd/lnrpc/metaservice_grpc.pb.go
+++ b/lnd/lnrpc/metaservice_grpc.pb.go
@@ -18,15 +18,32 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type MetaServiceClient interface {
+	//
+	//$pld.category: `Meta`
+	//$pld.short_description: `Returns basic information related to the active daemon`
+	//
+	//GetInfo returns general information concerning the lightning node including
+	//it's identity pubkey, alias, the chains it is connected to, and information
+	//concerning the number of open+pending channels.
 	GetInfo2(ctx context.Context, in *GetInfo2Request, opts ...grpc.CallOption) (*GetInfo2Response, error)
-	// lncli: `changepassword`
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Change an encrypted wallet's password at startup`
+	//
 	//ChangePassword changes the password of the encrypted wallet. This will
 	//automatically unlock the wallet database if successful.
 	ChangePassword(ctx context.Context, in *ChangePasswordRequest, opts ...grpc.CallOption) (*ChangePasswordResponse, error)
-	// lncli: `checkPassword`
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Check the wallet's password`
+	//
 	//CheckPassword verify that the password in the request is valid for the wallet.
 	CheckPassword(ctx context.Context, in *CheckPasswordRequest, opts ...grpc.CallOption) (*CheckPasswordResponse, error)
-	//  Force a pld crash (for debug purposes)
+	//
+	//$pld.category: `Meta`
+	//$pld.short_description: `Force pld to crash (for debugging purposes)`
+	//
+	//Force a pld crash (for debugging purposes)
 	ForceCrash(ctx context.Context, in *CrashRequest, opts ...grpc.CallOption) (*CrashResponse, error)
 }
 
@@ -78,15 +95,32 @@ func (c *metaServiceClient) ForceCrash(ctx context.Context, in *CrashRequest, op
 // All implementations should embed UnimplementedMetaServiceServer
 // for forward compatibility
 type MetaServiceServer interface {
+	//
+	//$pld.category: `Meta`
+	//$pld.short_description: `Returns basic information related to the active daemon`
+	//
+	//GetInfo returns general information concerning the lightning node including
+	//it's identity pubkey, alias, the chains it is connected to, and information
+	//concerning the number of open+pending channels.
 	GetInfo2(context.Context, *GetInfo2Request) (*GetInfo2Response, error)
-	// lncli: `changepassword`
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Change an encrypted wallet's password at startup`
+	//
 	//ChangePassword changes the password of the encrypted wallet. This will
 	//automatically unlock the wallet database if successful.
 	ChangePassword(context.Context, *ChangePasswordRequest) (*ChangePasswordResponse, error)
-	// lncli: `checkPassword`
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Check the wallet's password`
+	//
 	//CheckPassword verify that the password in the request is valid for the wallet.
 	CheckPassword(context.Context, *CheckPasswordRequest) (*CheckPasswordResponse, error)
-	//  Force a pld crash (for debug purposes)
+	//
+	//$pld.category: `Meta`
+	//$pld.short_description: `Force pld to crash (for debugging purposes)`
+	//
+	//Force a pld crash (for debugging purposes)
 	ForceCrash(context.Context, *CrashRequest) (*CrashResponse, error)
 }
 

--- a/lnd/lnrpc/restrpc/help/help.go
+++ b/lnd/lnrpc/restrpc/help/help.go
@@ -101,62 +101,63 @@ const (
 	CommandResetMc       = "ResetMissionControl"
 	CommandBuildRoute    = "BuildRoute"
 	//	lightning/peer subCategory command
-	CommandConnectPeer    = "connectpeer"
-	CommandDisconnectPeer = "disconnectpeer"
-	CommandListPeers      = "listpeers"
+	CommandConnectPeer    = "ConnectPeer"
+	CommandDisconnectPeer = "DisconnectPeer"
+	CommandListPeers      = "ListPeers"
 	//	meta category command
-	CommandDebugLevel = "debuglevel"
-	CommandGetInfo    = "getinfo"
-	CommandStop       = "stop"
-	CommandVersion    = "version"
-	CommandCrash      = "crash"
+	CommandDebugLevel = "DebugLevel"
+	CommandGetInfo    = "GetInfo2"
+	CommandStop       = "StopDaemon"
+	CommandVersion    = "GetVersion"
+	CommandCrash      = "ForceCrash"
 	//	wallet category command
 	CommandWalletBalance    = "WalletBalance"
-	CommandChangePassphrase = "changePassphrase"
-	CommandCheckPassphrase  = "checkPassphrase"
-	CommandCreateWallet     = "createwallet"
-	CommandGetSecret        = "getsecret"
-	CommandGetWalletSeed    = "getwalletseed"
-	CommandUnlockWallet     = "unlockwallet"
+	CommandChangePassphrase = "ChangePassword"
+	CommandCheckPassphrase  = "CheckPassword"
+	CommandCreateWallet     = "InitWallet"
+	CommandGetSecret        = "GetSecret"
+	CommandGetWalletSeed    = "GetWalletSeed"
+	CommandUnlockWallet     = "UnlockWallet"
 	//	wallet/networkstewardvote subCategory command
-	CommandGetNetworkStewardVote = "getnetworkstewardvote"
-	CommandSetNetworkStewardVote = "setnetworkstewardvote"
+	CommandGetNetworkStewardVote = "GetNetworkStewardVote"
+	CommandSetNetworkStewardVote = "SetNetworkStewardVote"
 	//	wallet/transaction subCategory command
-	CommandGetTransaction    = "gettransaction"
-	CommandCreateTransaction = "createtransaction"
-	CommandQueryTransactions = "querytransactions"
-	CommandSendCoins         = "sendcoins"
-	CommandSendFrom          = "sendfrom"
-	CommandSendMany          = "sendmany"
+	CommandGetTransaction    = "GetTransaction"
+	CommandCreateTransaction = "CreateTransaction"
+	CommandQueryTransactions = "GetTransactions"
+	CommandSendCoins         = "SendCoins"
+	CommandSendFrom          = "SendFrom"
+	CommandSendMany          = "SendMany"
 	//	wallet/unspent subCategory command
-	CommandListUnspent = "listunspent"
-	CommandResync      = "resync"
-	CommandStopResync  = "stopresync"
+	CommandListUnspent = "ListUnspent"
+	CommandResync      = "ReSync"
+	CommandStopResync  = "StopReSync"
 	//	wallet/unspent/lock subCategory command
-	CommandListLockUnspent = "listlockunspent"
-	CommandLockUnspent     = "lockunspent"
+	CommandListLockUnspent = "ListLockUnspent"
+	CommandLockUnspent     = "LockUnspent"
 	//	wallet/address subCategory command
-	CommandGetAddressBalances = "getaddressbalances"
-	CommandNewAddress         = "newaddress"
-	CommandDumpPrivkey        = "dumpprivkey"
-	CommandImportPrivkey      = "importprivkey"
-	CommandSignMessage        = "signmessage"
+	CommandGetAddressBalances = "GetAddressBalances"
+	CommandNewAddress         = "GetNewAddress"
+	CommandDumpPrivkey        = "DumpPrivKey"
+	CommandImportPrivkey      = "ImportPrivKey"
+	CommandSignMessage        = "SignMessage"
 	//	neutrino category command
-	CommandBcastTransaction = "bcasttransaction"
-	CommandEstimateFee      = "estimatefee"
+	CommandBcastTransaction = "BcastTransaction"
+	CommandEstimateFee      = "EstimateFee"
 	//	util/seed subCategory command
-	CommandChangeSeedPassphrase = "changeseedpassphrase"
-	CommandGenSeed              = "genseed"
+	CommandChangeSeedPassphrase = "ChangeSeedPassphrase"
+	CommandGenSeed              = "GenSeed"
 	//	wtclient/tower subCategory command
-	CommandCreateWatchTower = "createwatchtower"
-	CommandRemoveTower      = "removewatchtower"
-	CommandListTowers       = "listtowers"
-	CommandGetTowerInfo     = "gettowerinfo"
-	CommandGetTowerStats    = "gettowerstats"
-	CommandGetTowerPolicy   = "gettowerpolicy"
+	CommandCreateWatchTower = "AddTower"
+	CommandRemoveTower      = "RemoveTower"
+	CommandListTowers       = "ListTowers"
+	CommandGetTowerInfo     = "GetTowerInfo"
+	CommandGetTowerStats    = "Stats"
+	CommandGetTowerPolicy   = "Policy"
 )
 
 type CommandInfo struct {
+	Command     string
 	Category    string
 	Description string
 	Path        string
@@ -166,334 +167,100 @@ type CommandInfo struct {
 
 //	mapping with the category, description and path for every command
 var (
-	CommandInfoData map[string]CommandInfo = map[string]CommandInfo{
+	CommandInfoData []CommandInfo = []CommandInfo{
 		//	lightning/channel subCategory commands
-		CommandOpenChannel:     {Path: "/lightning/channel/open"},
-		CommandCloseChannel:    {Path: "/lightning/channel/close"},
-		CommandAbandonChannel:  {Path: "/lightning/channel/abandon"},
-		CommandChannelBalance:  {Path: "/lightning/channel/balance"},
-		CommandPendingChannels: {Path: "/lightning/channel/pending"},
-		CommandListChannels: {
-			Path:     "/lightning/channel",
-			AllowGet: true,
-		},
-		CommandClosedChannels: {
-			Path:     "/lightning/channel/closed",
-			AllowGet: true,
-		},
-		CommandGetNetworkInfo:   {Path: "/lightning/channel/networkinfo"},
-		CommandFeeReport:        {Path: "/lightning/channel/feereport"},
-		CommandUpdateChanPolicy: {Path: "/lightning/channel/policy"},
+		{Command: CommandOpenChannel, Path: "/lightning/channel/open"},
+		{Command: CommandCloseChannel, Path: "/lightning/channel/close"},
+		{Command: CommandAbandonChannel, Path: "/lightning/channel/abandon"},
+		{Command: CommandChannelBalance, Path: "/lightning/channel/balance"},
+		{Command: CommandPendingChannels, Path: "/lightning/channel/pending"},
+		{Command: CommandListChannels, Path: "/lightning/channel", AllowGet: true},
+		{Command: CommandClosedChannels, Path: "/lightning/channel/closed", AllowGet: true},
+		{Command: CommandGetNetworkInfo, Path: "/lightning/channel/networkinfo"},
+		{Command: CommandFeeReport, Path: "/lightning/channel/feereport"},
+		{Command: CommandUpdateChanPolicy, Path: "/lightning/channel/policy"},
 		//	lightning/channel/backup subCategory commands
-		CommandExportChanBackup:  {Path: "/lightning/channel/backup/export"},
-		CommandVerifyChanBackup:  {Path: "/lightning/channel/backup/verify"},
-		CommandRestoreChanBackup: {Path: "/lightning/channel/backup/restore"},
+		{Command: CommandExportChanBackup, Path: "/lightning/channel/backup/export"},
+		{Command: CommandVerifyChanBackup, Path: "/lightning/channel/backup/verify"},
+		{Command: CommandRestoreChanBackup, Path: "/lightning/channel/backup/restore"},
 		//	lightning/graph subCategory commands
-		CommandDescribeGraph: {
-			Path:     "/lightning/graph",
-			AllowGet: true,
-		},
-		CommandGetNodeMetrics: {
-			Path:     "/lightning/graph/nodemetrics",
-			AllowGet: true,
-		},
-		CommandGetChanInfo: {Path: "/lightning/graph/channel"},
-		CommandGetNodeInfo: {Path: "/lightning/graph/nodeinfo"},
+		{Command: CommandDescribeGraph, Path: "/lightning/graph", AllowGet: true},
+		{Command: CommandGetNodeMetrics, Path: "/lightning/graph/nodemetrics", AllowGet: true},
+		{Command: CommandGetChanInfo, Path: "/lightning/graph/channel"},
+		{Command: CommandGetNodeInfo, Path: "/lightning/graph/nodeinfo"},
 		//	lightning/invoice subCategory commands
-		CommandAddInvoice:    {Path: "/lightning/invoice/create"},
-		CommandLookupInvoice: {Path: "/lightning/invoice/lookup"},
-		CommandListInvoices: {
-			Path:     "/lightning/invoice",
-			AllowGet: true,
-		},
-		CommandDecodePayreq: {Path: "/lightning/invoice/decodepayreq"},
+		{Command: CommandAddInvoice, Path: "/lightning/invoice/create"},
+		{Command: CommandLookupInvoice, Path: "/lightning/invoice/lookup"},
+		{Command: CommandListInvoices, Path: "/lightning/invoice", AllowGet: true},
+		{Command: CommandDecodePayreq, Path: "/lightning/invoice/decodepayreq"},
 		//	lightning/payment subCategory command
-		CommandSendPayment: {Path: "/lightning/payment/send"},
-		CommandPayInvoice: {
-			Description: "Pay an invoice over lightning",
-			Path:        "/lightning/payment/payinvoice",
-		},
-		CommandSendToRoute: {Path: "/lightning/payment/sendtoroute"},
-		CommandListPayments: {
-			Path:     "/lightning/payment",
-			AllowGet: true,
-		},
-		CommandTrackPayment:  {Path: "/lightning/payment/track"},
-		CommandQueryRoutes:   {Path: "/lightning/payment/queryroutes"},
-		CommandFwdingHistory: {Path: "/lightning/payment/fwdinghistory"},
-		CommandQueryMc:       {Path: "/lightning/payment/querymc"},
-		CommandQueryProb:     {Path: "/lightning/payment/queryprob"},
-		CommandResetMc:       {Path: "/lightning/payment/resetmc"},
-		CommandBuildRoute:    {Path: "/lightning/payment/buildroute"},
+		{Command: CommandSendPayment, Path: "/lightning/payment/send"},
+		//	TODO: need to understand what command does the PayInvoice functionality
+		{Command: CommandPayInvoice, Description: "Pay an invoice over lightning", Path: "/lightning/payment/payinvoice"},
+		{Command: CommandSendToRoute, Path: "/lightning/payment/sendtoroute"},
+		{Command: CommandListPayments, Path: "/lightning/payment", AllowGet: true},
+		{Command: CommandTrackPayment, Path: "/lightning/payment/track"},
+		{Command: CommandQueryRoutes, Path: "/lightning/payment/queryroutes"},
+		{Command: CommandFwdingHistory, Path: "/lightning/payment/fwdinghistory"},
+		{Command: CommandQueryMc, Path: "/lightning/payment/querymc"},
+		{Command: CommandQueryProb, Path: "/lightning/payment/queryprob"},
+		{Command: CommandResetMc, Path: "/lightning/payment/resetmc"},
+		{Command: CommandBuildRoute, Path: "/lightning/payment/buildroute"},
 		//	lightning/peer subCategory command
-		CommandConnectPeer: {
-			Category:    SubCategoryPeer,
-			Description: "Connect to a remote pld peer",
-			Path:        "/lightning/peer/connect",
-			HelpInfo:    pkthelp.Lightning_ConnectPeer,
-		},
-		CommandDisconnectPeer: {
-			Category:    SubCategoryPeer,
-			Description: "Disconnect a remote pld peer identified by public key",
-			Path:        "/lightning/peer/disconnect",
-			HelpInfo:    pkthelp.Lightning_DisconnectPeer,
-		},
-		CommandListPeers: {
-			Category:    SubCategoryPeer,
-			Description: "List all active, currently connected peers",
-			Path:        "/lightning/peer",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.Lightning_ListPeers,
-		},
+		{Command: CommandConnectPeer, Path: "/lightning/peer/connect"},
+		{Command: CommandDisconnectPeer, Path: "/lightning/peer/disconnect"},
+		{Command: CommandListPeers, Path: "/lightning/peer", AllowGet: true},
 		//	meta category command
-		CommandDebugLevel: {
-			Category:    CategoryMeta,
-			Description: "Set the debug level",
-			Path:        "/meta/debuglevel",
-			HelpInfo:    pkthelp.Lightning_DebugLevel,
-		},
-		CommandGetInfo: {
-			Category:    CategoryMeta,
-			Description: "Returns basic information related to the active daemon",
-			Path:        "/meta/getinfo",
-			HelpInfo:    pkthelp.Lightning_GetInfo,
-		},
-		CommandStop: {
-			Category:    CategoryMeta,
-			Description: "Stop and shutdown the daemon",
-			Path:        "/meta/stop",
-			HelpInfo:    pkthelp.Lightning_StopDaemon,
-		},
-		CommandVersion: {
-			Category:    CategoryMeta,
-			Description: "Display pldctl and pld version info",
-			Path:        "/meta/version",
-			HelpInfo:    pkthelp.Versioner_GetVersion,
-		},
-		CommandCrash: {
-			Category:    CategoryMeta,
-			Description: "Force pld to crash (for debugging purposes)",
-			Path:        "/meta/crash",
-			HelpInfo:    pkthelp.MetaService_ForceCrash,
-		},
+		{Command: CommandDebugLevel, Path: "/meta/debuglevel"},
+		{Command: CommandGetInfo, Path: "/meta/getinfo"},
+		{Command: CommandStop, Path: "/meta/stop"},
+		{Command: CommandVersion, Path: "/meta/version"},
+		{Command: CommandCrash, Path: "/meta/crash"},
 		//	wallet category command
-		CommandWalletBalance: {Path: "/wallet/balance"},
-		CommandChangePassphrase: {
-			Category:    CategoryWallet,
-			Description: "Change an encrypted wallet's password at startup",
-			Path:        "/wallet/changepassphrase",
-			HelpInfo:    pkthelp.MetaService_ChangePassword,
-		},
-		CommandCheckPassphrase: {
-			Category:    CategoryWallet,
-			Description: "Check the wallet's password",
-			Path:        "/wallet/checkpassphrase",
-			HelpInfo:    pkthelp.MetaService_CheckPassword,
-		},
-		CommandCreateWallet: {
-			Category:    CategoryWallet,
-			Description: "Initialize a wallet when starting lnd for the first time",
-			Path:        "/wallet/create",
-			HelpInfo:    pkthelp.WalletUnlocker_InitWallet,
-		},
-		CommandGetSecret: {
-			Category:    CategoryWallet,
-			Description: "Get a secret seed",
-			Path:        "/wallet/getsecret",
-			HelpInfo:    pkthelp.Lightning_GetSecret,
-		},
-		CommandGetWalletSeed: {
-			Category:    CategoryWallet,
-			Description: "Get the wallet seed words for this wallet",
-			Path:        "/wallet/seed",
-			HelpInfo:    pkthelp.Lightning_GetWalletSeed,
-		},
-		CommandUnlockWallet: {
-			Category:    CategoryWallet,
-			Description: "Unlock an encrypted wallet at startup",
-			Path:        "/wallet/unlock",
-			HelpInfo:    pkthelp.WalletUnlocker_UnlockWallet,
-		},
+		{Command: CommandWalletBalance, Path: "/wallet/balance"},
+		{Command: CommandChangePassphrase, Path: "/wallet/changepassphrase"},
+		{Command: CommandCheckPassphrase, Path: "/wallet/checkpassphrase"},
+		{Command: CommandCreateWallet, Path: "/wallet/create"},
+		{Command: CommandGetSecret, Path: "/wallet/getsecret"},
+		{Command: CommandGetWalletSeed, Path: "/wallet/seed"},
+		{Command: CommandUnlockWallet, Path: "/wallet/unlock"},
 		//	wallet/networkstewardvote subCategory command
-		CommandGetNetworkStewardVote: {
-			Category:    SubCategoryNetworkStewardVote,
-			Description: "Find out how the wallet is currently configured to vote in a network steward election",
-			Path:        "/wallet/networkstewardvote",
-			HelpInfo:    pkthelp.Lightning_GetNetworkStewardVote,
-		},
-		CommandSetNetworkStewardVote: {
-			Category:    SubCategoryNetworkStewardVote,
-			Description: "Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)",
-			Path:        "/wallet/networkstewardvote/set",
-			HelpInfo:    pkthelp.Lightning_SetNetworkStewardVote,
-		},
+		{Command: CommandGetNetworkStewardVote, Path: "/wallet/networkstewardvote"},
+		{Command: CommandSetNetworkStewardVote, Path: "/wallet/networkstewardvote/set"},
 		//	wallet/transaction subCategory command
-		CommandGetTransaction: {
-			Category:    SubCategoryTransaction,
-			Description: "Returns a JSON object with details regarding a transaction relevant to this wallet",
-			Path:        "/wallet/transaction",
-			HelpInfo:    pkthelp.Lightning_GetTransaction,
-		},
-		CommandCreateTransaction: {
-			Category:    SubCategoryTransaction,
-			Description: "Create a transaction but do not send it to the chain",
-			Path:        "/wallet/transaction/create",
-			HelpInfo:    pkthelp.Lightning_CreateTransaction,
-		},
-		CommandQueryTransactions: {
-			Category:    SubCategoryTransaction,
-			Description: "List transactions from the wallet",
-			Path:        "/wallet/transaction/query",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.Lightning_GetTransactions,
-		},
-		CommandSendCoins: {
-			Category:    SubCategoryTransaction,
-			Description: "Send bitcoin on-chain to an address",
-			Path:        "/wallet/transaction/sendcoins",
-			HelpInfo:    pkthelp.Lightning_SendCoins,
-		},
-		CommandSendFrom: {
-			Category:    SubCategoryTransaction,
-			Description: "Authors, signs, and sends a transaction that outputs some amount to a payment address",
-			Path:        "/wallet/transaction/sendfrom",
-			HelpInfo:    pkthelp.Lightning_SendFrom,
-		},
-		CommandSendMany: {
-			Category:    SubCategoryTransaction,
-			Description: "Send bitcoin on-chain to multiple addresses",
-			Path:        "/wallet/transaction/sendmany",
-			HelpInfo:    pkthelp.Lightning_SendMany,
-		},
+		{Command: CommandGetTransaction, Path: "/wallet/transaction"},
+		{Command: CommandCreateTransaction, Path: "/wallet/transaction/create"},
+		{Command: CommandQueryTransactions, Path: "/wallet/transaction/query", AllowGet: true},
+		{Command: CommandSendCoins, Path: "/wallet/transaction/sendcoins"},
+		{Command: CommandSendFrom, Path: "/wallet/transaction/sendfrom"},
+		{Command: CommandSendMany, Path: "/wallet/transaction/sendmany"},
 		//	wallet/unspent subCategory command
-		CommandListUnspent: {
-			Category:    SubCategoryUnspent,
-			Description: "List utxos available for spending",
-			Path:        "/wallet/unspent",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.Lightning_ListUnspent,
-		},
-		CommandResync: {
-			Category:    SubCategoryUnspent,
-			Description: "Scan over the chain to find any transactions which may not have been recorded in the wallet's database",
-			Path:        "/wallet/unspent/resync",
-			HelpInfo:    pkthelp.Lightning_ReSync,
-		},
-		CommandStopResync: {
-			Category:    SubCategoryUnspent,
-			Description: "Stop a re-synchronization job before it's completion",
-			Path:        "/wallet/unspent/stopresync",
-			HelpInfo:    pkthelp.Lightning_StopReSync,
-		},
+		{Command: CommandListUnspent, Path: "/wallet/unspent", AllowGet: true},
+		{Command: CommandResync, Path: "/wallet/unspent/resync"},
+		{Command: CommandStopResync, Path: "/wallet/unspent/stopresync"},
 		//	wallet/unspent/lock subCategory command
-		CommandListLockUnspent: {
-			Category:    SubSubCategoryLock,
-			Description: "Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session",
-			Path:        "/wallet/unspent/lock",
-			HelpInfo:    pkthelp.Lightning_ListLockUnspent,
-		},
-		CommandLockUnspent: {
-			Category:    SubSubCategoryLock,
-			Description: "Locks or unlocks an unspent output",
-			Path:        "/wallet/unspent/lock/create", // TODO: /wallet/unspent/lock/delete
-			HelpInfo:    pkthelp.Lightning_LockUnspent,
-		},
+		{Command: CommandListLockUnspent, Path: "/wallet/unspent/lock"},
+		{Command: CommandLockUnspent, Path: "/wallet/unspent/lock/create"},
+		// TODO: need to create a /wallet/unspent/lock/delete command
 		//	wallet/address subCategory command
-		CommandGetAddressBalances: {
-			Category:    SubCategoryAddress,
-			Description: "Compute and display balances for each address in the wallet",
-			Path:        "/wallet/address/balances",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.Lightning_GetAddressBalances,
-		},
-		CommandNewAddress: {
-			Category:    SubCategoryAddress,
-			Description: "Generates a new address",
-			Path:        "/wallet/address/create",
-			HelpInfo:    pkthelp.Lightning_GetNewAddress,
-		},
-		CommandDumpPrivkey: {
-			Category:    SubCategoryAddress,
-			Description: "Returns the private key in WIF encoding that controls some wallet address",
-			Path:        "/wallet/address/dumpprivkey",
-			HelpInfo:    pkthelp.Lightning_DumpPrivKey,
-		},
-		CommandImportPrivkey: {
-			Category:    SubCategoryAddress,
-			Description: "Imports a WIF-encoded private key to the 'imported' account",
-			Path:        "/wallet/address/import",
-			HelpInfo:    pkthelp.Lightning_ImportPrivKey,
-		},
-		CommandSignMessage: {
-			Category:    SubCategoryAddress,
-			Description: "Signs a message using the private key of a payment address",
-			Path:        "/wallet/address/signmessage",
-			HelpInfo:    pkthelp.Signer_SignMessage,
-		},
+		{Command: CommandGetAddressBalances, Path: "/wallet/address/balances", AllowGet: true},
+		{Command: CommandNewAddress, Path: "/wallet/address/create"},
+		{Command: CommandDumpPrivkey, Path: "/wallet/address/dumpprivkey"},
+		{Command: CommandImportPrivkey, Path: "/wallet/address/import"},
+		{Command: CommandSignMessage, Path: "/wallet/address/signmessage"},
 		//	neutrino category command
-		CommandBcastTransaction: {
-			Category:    CategoryNeutrino,
-			Description: "Broadcast a transaction onchain",
-			Path:        "/neutrino/bcasttransaction",
-			HelpInfo:    pkthelp.Lightning_BcastTransaction,
-		},
-		CommandEstimateFee: {
-			Category:    CategoryNeutrino,
-			Description: "Get fee estimates for sending bitcoin on-chain to multiple addresses",
-			Path:        "/neutrino/estimatefee",
-			HelpInfo:    pkthelp.Lightning_EstimateFee,
-		},
+		{Command: CommandBcastTransaction, Path: "/neutrino/bcasttransaction"},
+		{Command: CommandEstimateFee, Path: "/neutrino/estimatefee"},
 		//	util/seed subCategory command
-		CommandChangeSeedPassphrase: {
-			Category:    SubCategorySeed,
-			Description: "Alter the passphrase which is used to encrypt a wallet seed",
-			Path:        "/util/seed/changepassphrase",
-			HelpInfo:    pkthelp.Lightning_ChangeSeedPassphrase,
-		},
-		CommandGenSeed: {
-			Category:    SubCategorySeed,
-			Description: "Create a secret seed",
-			Path:        "/util/seed/create",
-			HelpInfo:    pkthelp.WalletUnlocker_GenSeed,
-		},
+		{Command: CommandChangeSeedPassphrase, Path: "/util/seed/changepassphrase"},
+		{Command: CommandGenSeed, Path: "/util/seed/create"},
 		//	wtclient/tower subCategory command
-		CommandCreateWatchTower: {
-			Category:    CategoryWatchtower,
-			Description: "Register a watchtower to use for future sessions/backups",
-			Path:        "/wtclient/tower/create",
-			HelpInfo:    pkthelp.WatchtowerClient_AddTower,
-		},
-		CommandRemoveTower: {
-			Category:    CategoryWatchtower,
-			Description: "Remove a watchtower to prevent its use for future sessions/backups",
-			Path:        "/wtclient/tower/remove",
-			HelpInfo:    pkthelp.WatchtowerClient_RemoveTower,
-		},
-		CommandListTowers: {
-			Category:    CategoryWatchtower,
-			Description: "Display information about all registered watchtowers",
-			Path:        "/wtclient/tower",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.WatchtowerClient_ListTowers,
-		},
-		CommandGetTowerInfo: {
-			Category:    CategoryWatchtower,
-			Description: "Display information about a specific registered watchtower",
-			Path:        "/wtclient/tower/getinfo",
-			HelpInfo:    pkthelp.WatchtowerClient_GetTowerInfo,
-		},
-		CommandGetTowerStats: {
-			Category:    CategoryWatchtower,
-			Description: "Display the session stats of the watchtower client",
-			Path:        "/wtclient/tower/stats",
-			HelpInfo:    pkthelp.WatchtowerClient_Stats,
-		},
-		CommandGetTowerPolicy: {
-			Category:    CategoryWatchtower,
-			Description: "Display the active watchtower client policy configuration",
-			Path:        "/wtclient/tower/policy",
-			HelpInfo:    pkthelp.WatchtowerClient_Policy,
-		},
+		{Command: CommandCreateWatchTower, Path: "/wtclient/tower/create"},
+		{Command: CommandRemoveTower, Path: "/wtclient/tower/remove"},
+		{Command: CommandListTowers, Path: "/wtclient/tower", AllowGet: true},
+		{Command: CommandGetTowerInfo, Path: "/wtclient/tower/getinfo"},
+		{Command: CommandGetTowerStats, Path: "/wtclient/tower/stats"},
+		{Command: CommandGetTowerPolicy, Path: "/wtclient/tower/policy"},
 	}
 )
 
@@ -527,6 +294,7 @@ func init() {
 		pkthelp.Lightning_DecodePayReq,
 
 		pkthelp.Router_SendPaymentV2,
+		//	PayInvoice
 		pkthelp.Router_SendToRouteV2,
 		pkthelp.Lightning_ListPayments,
 		pkthelp.Router_TrackPaymentV2,
@@ -537,18 +305,72 @@ func init() {
 		pkthelp.Router_ResetMissionControl,
 		pkthelp.Router_BuildRoute,
 
+		pkthelp.Lightning_ConnectPeer,
+		pkthelp.Lightning_DisconnectPeer,
+		pkthelp.Lightning_ListPeers,
+
+		pkthelp.Lightning_DebugLevel,
+		pkthelp.MetaService_GetInfo2,
+		pkthelp.Lightning_StopDaemon,
+		pkthelp.Versioner_GetVersion,
+		pkthelp.MetaService_ForceCrash,
+
 		pkthelp.Lightning_WalletBalance,
+		pkthelp.MetaService_ChangePassword,
+		pkthelp.MetaService_CheckPassword,
+		pkthelp.WalletUnlocker_InitWallet,
+		pkthelp.Lightning_GetSecret,
+		pkthelp.Lightning_GetWalletSeed,
+		pkthelp.WalletUnlocker_UnlockWallet,
+
+		pkthelp.Lightning_GetNetworkStewardVote,
+		pkthelp.Lightning_SetNetworkStewardVote,
+
+		pkthelp.Lightning_GetTransaction,
+		pkthelp.Lightning_CreateTransaction,
+		pkthelp.Lightning_GetTransactions,
+		pkthelp.Lightning_SendCoins,
+		pkthelp.Lightning_SendFrom,
+		pkthelp.Lightning_SendMany,
+
+		pkthelp.WalletKit_ListUnspent,
+		pkthelp.Lightning_ReSync,
+		pkthelp.Lightning_StopReSync,
+
+		pkthelp.Lightning_ListLockUnspent,
+		pkthelp.Lightning_LockUnspent,
+
+		pkthelp.Lightning_GetAddressBalances,
+		pkthelp.Lightning_GetNewAddress,
+		pkthelp.Lightning_DumpPrivKey,
+		pkthelp.Lightning_ImportPrivKey,
+		pkthelp.Signer_SignMessage,
+
+		pkthelp.Lightning_BcastTransaction,
+		pkthelp.Lightning_EstimateFee,
+
+		pkthelp.Lightning_ChangeSeedPassphrase,
+		pkthelp.WalletUnlocker_GenSeed,
+
+		pkthelp.WatchtowerClient_AddTower,
+		pkthelp.WatchtowerClient_RemoveTower,
+		pkthelp.WatchtowerClient_ListTowers,
+		pkthelp.WatchtowerClient_GetTowerInfo,
+		pkthelp.WatchtowerClient_Stats,
+		pkthelp.WatchtowerClient_Policy,
 	}
 
+	//	for each command help fuction set meta data to commandInfoData
 	for _, helpFunction := range commandHelpFunctions {
 
 		var commandMethod = helpFunction()
 
-		CommandInfoData[commandMethod.Name] = CommandInfo{
-			Category:    commandMethod.Category,
-			Description: commandMethod.ShortDescription,
-			Path:        CommandInfoData[commandMethod.Name].Path,
-			HelpInfo:    helpFunction,
+		for i, commandInfo := range CommandInfoData {
+			if commandMethod.Name == commandInfo.Command {
+				CommandInfoData[i].Category = commandMethod.Category
+				CommandInfoData[i].Description = commandMethod.ShortDescription
+				CommandInfoData[i].HelpInfo = helpFunction
+			}
 		}
 	}
 }

--- a/lnd/lnrpc/restrpc/help/help.go
+++ b/lnd/lnrpc/restrpc/help/help.go
@@ -64,42 +64,42 @@ var (
 //	constants for every pld command
 const (
 	//	lightning/channel subCategory commands
-	CommandOpenChannel      = "openchannel"
-	CommandCloseChannel     = "closechannel"
-	CommandAbandonChannel   = "abandonchannel"
-	CommandChannelBalance   = "channelbalance"
-	CommandPendingChannels  = "pendingchannels"
-	CommandListChannels     = "listchannels"
-	CommandClosedChannels   = "closedchannels"
-	CommandGetNetworkInfo   = "getnetworkinfo"
-	CommandFeeReport        = "feereport"
-	CommandUpdateChanPolicy = "updatechanpolicy"
+	CommandOpenChannel      = "OpenChannel"
+	CommandCloseChannel     = "CloseChannel"
+	CommandAbandonChannel   = "AbandonChannel"
+	CommandChannelBalance   = "ChannelBalance"
+	CommandPendingChannels  = "PendingChannels"
+	CommandListChannels     = "ListChannels"
+	CommandClosedChannels   = "ClosedChannels"
+	CommandGetNetworkInfo   = "GetNetworkInfo"
+	CommandFeeReport        = "FeeReport"
+	CommandUpdateChanPolicy = "UpdateChannelPolicy"
 	//	lightning/channel/backup subCategory commands
-	CommandExportChanBackup  = "exportchanbackup"
-	CommandVerifyChanBackup  = "verifychanbackup"
-	CommandRestoreChanBackup = "restorechanbackup"
+	CommandExportChanBackup  = "ExportChannelBackup"
+	CommandVerifyChanBackup  = "VerifyChanBackup"
+	CommandRestoreChanBackup = "RestoreChannelBackups"
 	//	lightning/graph subCategory commands
-	CommandDescribeGraph  = "describegraph"
-	CommandGetNodeMetrics = "getnodemetrics"
-	CommandGetChanInfo    = "getchaninfo"
-	CommandGetNodeInfo    = "getnodeinfo"
+	CommandDescribeGraph  = "DescribeGraph"
+	CommandGetNodeMetrics = "GetNodeMetrics"
+	CommandGetChanInfo    = "GetChanInfo"
+	CommandGetNodeInfo    = "GetNodeInfo"
 	//	lightning/invoice subCategory commands
-	CommandAddInvoice    = "addinvoice"
-	CommandLookupInvoice = "lookupinvoice"
-	CommandListInvoices  = "listinvoices"
-	CommandDecodePayreq  = "decodepayreq"
+	CommandAddInvoice    = "AddInvoice"
+	CommandLookupInvoice = "LookupInvoice"
+	CommandListInvoices  = "ListInvoices"
+	CommandDecodePayreq  = "DecodePayReq"
 	//	lightning/payment subCategory command
-	CommandSendPayment   = "sendpayment"
+	CommandSendPayment   = "SendPaymentV2"
 	CommandPayInvoice    = "payinvoice"
-	CommandSendToRoute   = "sendtoroute"
-	CommandListPayments  = "listpayments"
-	CommandTrackPayment  = "trackpayment"
-	CommandQueryRoutes   = "queryroutes"
-	CommandFwdingHistory = "fwdinghistory"
-	CommandQueryMc       = "querymc"
-	CommandQueryProb     = "queryprob"
-	CommandResetMc       = "resetmc"
-	CommandBuildRoute    = "buildroute"
+	CommandSendToRoute   = "SendToRouteV2"
+	CommandListPayments  = "ListPayments"
+	CommandTrackPayment  = "TrackPaymentV2"
+	CommandQueryRoutes   = "QueryRoutes"
+	CommandFwdingHistory = "ForwardingHistory"
+	CommandQueryMc       = "QueryMissionControl"
+	CommandQueryProb     = "QueryProbability"
+	CommandResetMc       = "ResetMissionControl"
+	CommandBuildRoute    = "BuildRoute"
 	//	lightning/peer subCategory command
 	CommandConnectPeer    = "connectpeer"
 	CommandDisconnectPeer = "disconnectpeer"
@@ -111,7 +111,7 @@ const (
 	CommandVersion    = "version"
 	CommandCrash      = "crash"
 	//	wallet category command
-	CommandWalletBalance    = "walletbalance"
+	CommandWalletBalance    = "WalletBalance"
 	CommandChangePassphrase = "changePassphrase"
 	CommandCheckPassphrase  = "checkPassphrase"
 	CommandCreateWallet     = "createwallet"
@@ -168,208 +168,63 @@ type CommandInfo struct {
 var (
 	CommandInfoData map[string]CommandInfo = map[string]CommandInfo{
 		//	lightning/channel subCategory commands
-		CommandOpenChannel: {
-			Category:    SubcategoryChannel,
-			Description: "Open a channel to a node or an existing peer",
-			Path:        "/lightning/channel/open",
-			HelpInfo:    pkthelp.Lightning_OpenChannel,
-		},
-		CommandCloseChannel: {
-			Category:    SubcategoryChannel,
-			Description: "Close an existing channel",
-			Path:        "/lightning/channel/close",
-			HelpInfo:    pkthelp.Lightning_CloseChannel,
-		},
-		CommandAbandonChannel: {
-			Category:    SubcategoryChannel,
-			Description: "Abandons an existing channel",
-			Path:        "/lightning/channel/abandon",
-			HelpInfo:    pkthelp.Lightning_AbandonChannel,
-		},
-		CommandChannelBalance: {
-			Category:    SubcategoryChannel,
-			Description: "Returns the sum of the total available channel balance across all open channels",
-			Path:        "/lightning/channel/balance",
-			HelpInfo:    pkthelp.Lightning_ChannelBalance,
-		},
-		CommandPendingChannels: {
-			Category:    SubcategoryChannel,
-			Description: "Display information pertaining to pending channels",
-			Path:        "/lightning/channel/pending",
-			HelpInfo:    pkthelp.Lightning_PendingChannels,
-		},
+		CommandOpenChannel:     {Path: "/lightning/channel/open"},
+		CommandCloseChannel:    {Path: "/lightning/channel/close"},
+		CommandAbandonChannel:  {Path: "/lightning/channel/abandon"},
+		CommandChannelBalance:  {Path: "/lightning/channel/balance"},
+		CommandPendingChannels: {Path: "/lightning/channel/pending"},
 		CommandListChannels: {
-			Category:    SubcategoryChannel,
-			Description: "List all open channels",
-			Path:        "/lightning/channel",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.Lightning_ListChannels,
+			Path:     "/lightning/channel",
+			AllowGet: true,
 		},
 		CommandClosedChannels: {
-			Category:    SubcategoryChannel,
-			Description: "List all closed channels",
-			Path:        "/lightning/channel/closed",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.Lightning_ClosedChannels,
+			Path:     "/lightning/channel/closed",
+			AllowGet: true,
 		},
-		CommandGetNetworkInfo: {
-			Category:    SubcategoryChannel,
-			Description: "Get statistical information about the current state of the network",
-			Path:        "/lightning/channel/networkinfo",
-			HelpInfo:    pkthelp.Lightning_GetNetworkInfo,
-		},
-		CommandFeeReport: {
-			Category:    SubcategoryChannel,
-			Description: "Display the current fee policies of all active channels",
-			Path:        "/lightning/channel/feereport",
-			HelpInfo:    pkthelp.Lightning_FeeReport,
-		},
-		CommandUpdateChanPolicy: {
-			Category:    SubcategoryChannel,
-			Description: "Update the channel policy for all channels, or a single channel",
-			Path:        "/lightning/channel/policy",
-			HelpInfo:    pkthelp.Lightning_UpdateChannelPolicy,
-		},
+		CommandGetNetworkInfo:   {Path: "/lightning/channel/networkinfo"},
+		CommandFeeReport:        {Path: "/lightning/channel/feereport"},
+		CommandUpdateChanPolicy: {Path: "/lightning/channel/policy"},
 		//	lightning/channel/backup subCategory commands
-		CommandExportChanBackup: {
-			Category:    SubSubCategoryBackup,
-			Description: "Obtain a static channel back up for a selected channels, or all known channels",
-			Path:        "/lightning/channel/backup/export",
-			HelpInfo:    pkthelp.Lightning_ExportChannelBackup,
-		},
-		CommandRestoreChanBackup: {
-			Category:    SubSubCategoryBackup,
-			Description: "Verify an existing channel backup",
-			Path:        "/lightning/channel/backup/verify",
-			HelpInfo:    pkthelp.Lightning_VerifyChanBackup,
-		},
-		CommandVerifyChanBackup: {
-			Category:    SubSubCategoryBackup,
-			Description: "Restore an existing single or multi-channel static channel backup",
-			Path:        "/lightning/channel/backup/restore",
-			HelpInfo:    pkthelp.Lightning_RestoreChannelBackups,
-		},
+		CommandExportChanBackup:  {Path: "/lightning/channel/backup/export"},
+		CommandVerifyChanBackup:  {Path: "/lightning/channel/backup/verify"},
+		CommandRestoreChanBackup: {Path: "/lightning/channel/backup/restore"},
 		//	lightning/graph subCategory commands
 		CommandDescribeGraph: {
-			Category:    SubCategoryGraph,
-			Description: "Describe the network graph",
-			Path:        "/lightning/graph",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.Lightning_DescribeGraph,
+			Path:     "/lightning/graph",
+			AllowGet: true,
 		},
 		CommandGetNodeMetrics: {
-			Category:    SubCategoryGraph,
-			Description: "Get node metrics",
-			Path:        "/lightning/graph/nodemetrics",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.Lightning_GetNodeMetrics,
+			Path:     "/lightning/graph/nodemetrics",
+			AllowGet: true,
 		},
-		CommandGetChanInfo: {
-			Category:    SubCategoryGraph,
-			Description: "Get the state of a channel",
-			Path:        "/lightning/graph/channel",
-			HelpInfo:    pkthelp.Lightning_GetChanInfo,
-		},
-		CommandGetNodeInfo: {
-			Category:    SubCategoryGraph,
-			Description: "Get information on a specific node",
-			Path:        "/lightning/graph/nodeinfo",
-			HelpInfo:    pkthelp.Lightning_GetNodeInfo,
-		},
+		CommandGetChanInfo: {Path: "/lightning/graph/channel"},
+		CommandGetNodeInfo: {Path: "/lightning/graph/nodeinfo"},
 		//	lightning/invoice subCategory commands
-		CommandAddInvoice: {
-			Category:    SubCategoryInvoice,
-			Description: "Add a new invoice",
-			Path:        "/lightning/invoice/create",
-			HelpInfo:    pkthelp.Lightning_AddInvoice,
-		},
-		CommandLookupInvoice: {
-			Category:    SubCategoryInvoice,
-			Description: "Lookup an existing invoice by its payment hash",
-			Path:        "/lightning/invoice/lookup",
-			HelpInfo:    pkthelp.Lightning_LookupInvoice,
-		},
+		CommandAddInvoice:    {Path: "/lightning/invoice/create"},
+		CommandLookupInvoice: {Path: "/lightning/invoice/lookup"},
 		CommandListInvoices: {
-			Category:    SubCategoryInvoice,
-			Description: "List all invoices currently stored within the database. Any active debug invoices are ignored",
-			Path:        "/lightning/invoice",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.Lightning_ListInvoices,
+			Path:     "/lightning/invoice",
+			AllowGet: true,
 		},
-		CommandDecodePayreq: {
-			Category:    SubCategoryInvoice,
-			Description: "Decode a payment request",
-			Path:        "/lightning/invoice/decodepayreq",
-			HelpInfo:    pkthelp.Lightning_DecodePayReq,
-		},
+		CommandDecodePayreq: {Path: "/lightning/invoice/decodepayreq"},
 		//	lightning/payment subCategory command
-		CommandSendPayment: {
-			Category:    SubCategoryPayment,
-			Description: "Send a payment over lightning",
-			Path:        "/lightning/payment/send",
-			HelpInfo:    pkthelp.Lightning_SendPaymentSync,
-		},
+		CommandSendPayment: {Path: "/lightning/payment/send"},
 		CommandPayInvoice: {
-			Category:    SubCategoryPayment,
 			Description: "Pay an invoice over lightning",
 			Path:        "/lightning/payment/payinvoice",
-			HelpInfo:    nil,
 		},
-		CommandSendToRoute: {
-			Category:    SubCategoryPayment,
-			Description: "Send a payment over a predefined route",
-			Path:        "/lightning/payment/sendtoroute",
-			HelpInfo:    pkthelp.Lightning_SendToRouteSync,
-		},
+		CommandSendToRoute: {Path: "/lightning/payment/sendtoroute"},
 		CommandListPayments: {
-			Category:    SubCategoryPayment,
-			Description: "List all outgoing payments",
-			Path:        "/lightning/payment",
-			AllowGet:    true,
-			HelpInfo:    pkthelp.Lightning_ListPayments,
+			Path:     "/lightning/payment",
+			AllowGet: true,
 		},
-		CommandTrackPayment: {
-			Category:    SubCategoryPayment,
-			Description: "Track payment",
-			Path:        "/lightning/payment/track",
-			HelpInfo:    nil,
-		},
-		CommandQueryRoutes: {
-			Category:    SubCategoryPayment,
-			Description: "Query a route to a destination",
-			Path:        "/lightning/payment/queryroutes",
-			HelpInfo:    pkthelp.Lightning_QueryRoutes,
-		},
-		CommandFwdingHistory: {
-			Category:    SubCategoryPayment,
-			Description: "Query the history of all forwarded HTLCs",
-			Path:        "/lightning/payment/fwdinghistory",
-			HelpInfo:    pkthelp.Lightning_ForwardingHistory,
-		},
-		CommandQueryMc: {
-			Category:    SubCategoryPayment,
-			Description: "Query the internal mission control state",
-			Path:        "/lightning/payment/querymc",
-			HelpInfo:    pkthelp.Router_QueryMissionControl,
-		},
-		CommandQueryProb: {
-			Category:    SubCategoryPayment,
-			Description: "Estimate a success probability",
-			Path:        "/lightning/payment/queryprob",
-			HelpInfo:    pkthelp.Router_QueryProbability,
-		},
-		CommandResetMc: {
-			Category:    SubCategoryPayment,
-			Description: "Reset internal mission control state",
-			Path:        "/lightning/payment/resetmc",
-			HelpInfo:    pkthelp.Router_ResetMissionControl,
-		},
-		CommandBuildRoute: {
-			Category:    SubCategoryPayment,
-			Description: "Build a route from a list of hop pubkeys",
-			Path:        "/lightning/payment/buildroute",
-			HelpInfo:    pkthelp.Router_BuildRoute,
-		},
+		CommandTrackPayment:  {Path: "/lightning/payment/track"},
+		CommandQueryRoutes:   {Path: "/lightning/payment/queryroutes"},
+		CommandFwdingHistory: {Path: "/lightning/payment/fwdinghistory"},
+		CommandQueryMc:       {Path: "/lightning/payment/querymc"},
+		CommandQueryProb:     {Path: "/lightning/payment/queryprob"},
+		CommandResetMc:       {Path: "/lightning/payment/resetmc"},
+		CommandBuildRoute:    {Path: "/lightning/payment/buildroute"},
 		//	lightning/peer subCategory command
 		CommandConnectPeer: {
 			Category:    SubCategoryPeer,
@@ -422,12 +277,7 @@ var (
 			HelpInfo:    pkthelp.MetaService_ForceCrash,
 		},
 		//	wallet category command
-		CommandWalletBalance: {
-			Category:    CategoryWallet,
-			Description: "Compute and display the wallet's current balance",
-			Path:        "/wallet/balance",
-			HelpInfo:    pkthelp.Lightning_WalletBalance,
-		},
+		CommandWalletBalance: {Path: "/wallet/balance"},
 		CommandChangePassphrase: {
 			Category:    CategoryWallet,
 			Description: "Change an encrypted wallet's password at startup",
@@ -646,6 +496,62 @@ var (
 		},
 	}
 )
+
+//	init command info data by getting meta fields from help based on command name
+func init() {
+
+	var commandHelpFunctions []func() pkthelp.Method = []func() pkthelp.Method{
+		pkthelp.Lightning_OpenChannel,
+		pkthelp.Lightning_CloseChannel,
+		pkthelp.Lightning_AbandonChannel,
+		pkthelp.Lightning_ChannelBalance,
+		pkthelp.Lightning_PendingChannels,
+		pkthelp.Lightning_ListChannels,
+		pkthelp.Lightning_ClosedChannels,
+		pkthelp.Lightning_GetNetworkInfo,
+		pkthelp.Lightning_FeeReport,
+		pkthelp.Lightning_UpdateChannelPolicy,
+
+		pkthelp.Lightning_ExportChannelBackup,
+		pkthelp.Lightning_VerifyChanBackup,
+		pkthelp.Lightning_RestoreChannelBackups,
+
+		pkthelp.Lightning_DescribeGraph,
+		pkthelp.Lightning_GetNodeMetrics,
+		pkthelp.Lightning_GetChanInfo,
+		pkthelp.Lightning_GetNodeInfo,
+
+		pkthelp.Lightning_AddInvoice,
+		pkthelp.Lightning_LookupInvoice,
+		pkthelp.Lightning_ListInvoices,
+		pkthelp.Lightning_DecodePayReq,
+
+		pkthelp.Router_SendPaymentV2,
+		pkthelp.Router_SendToRouteV2,
+		pkthelp.Lightning_ListPayments,
+		pkthelp.Router_TrackPaymentV2,
+		pkthelp.Lightning_QueryRoutes,
+		pkthelp.Lightning_ForwardingHistory,
+		pkthelp.Router_QueryMissionControl,
+		pkthelp.Router_QueryProbability,
+		pkthelp.Router_ResetMissionControl,
+		pkthelp.Router_BuildRoute,
+
+		pkthelp.Lightning_WalletBalance,
+	}
+
+	for _, helpFunction := range commandHelpFunctions {
+
+		var commandMethod = helpFunction()
+
+		CommandInfoData[commandMethod.Name] = CommandInfo{
+			Category:    commandMethod.Category,
+			Description: commandMethod.ShortDescription,
+			Path:        CommandInfoData[commandMethod.Name].Path,
+			HelpInfo:    helpFunction,
+		}
+	}
+}
 
 //	the category help in REST master
 func RESTCategory_help(category string, subCategory []*RestCommandCategory) *RestCommandCategory {

--- a/lnd/lnrpc/restrpc/restrpc.go
+++ b/lnd/lnrpc/restrpc/restrpc.go
@@ -2283,8 +2283,13 @@ func marshal(w http.ResponseWriter, m proto.Message, isJson bool) er.R {
 }
 
 func (s *SimpleHandler) ServeHttpOrErr(w http.ResponseWriter, r *http.Request, isJson bool) er.R {
-	var commandInfo = help.CommandInfoData[s.rf.command]
-	var req proto.Message
+	var commandInfo help.CommandInfo
+
+	for _, commandInfo = range help.CommandInfoData {
+		if commandInfo.Command == s.rf.command {
+			break
+		}
+	}
 
 	//	check if the URI is for command help
 	if r.RequestURI == help.URI_prefix+helpURI_prefix+commandInfo.Path {
@@ -2307,6 +2312,8 @@ func (s *SimpleHandler) ServeHttpOrErr(w http.ResponseWriter, r *http.Request, i
 	}
 
 	//	command URI handler
+	var req proto.Message
+
 	if s.rf.req != nil {
 		if r.Method != "POST" {
 			//	if it's not a POST, check if the endpoint allows GET
@@ -2375,7 +2382,20 @@ func (s *SimpleHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func RestHandlers(c *RpcContext) *mux.Router {
 	r := mux.NewRouter()
 	for _, rf := range rpcFunctions {
-		var commandInfo = help.CommandInfoData[rf.command]
+		var commandInfo help.CommandInfo
+		var commandFound bool
+
+		for _, commandInfo = range help.CommandInfoData {
+			if commandInfo.Command == rf.command {
+				commandFound = true
+				break
+			}
+		}
+		//	if all commands in s.rf (rpcFunctions) slice have an entry in help.CommandInfoData
+		//		this panic condition will never be reached
+		if !commandFound {
+			panic("[panic] Command info about command " + rf.command + "not found")
+		}
 
 		r.Handle(help.URI_prefix+commandInfo.Path, &SimpleHandler{c: c, rf: rf})
 		r.Handle(help.URI_prefix+helpURI_prefix+commandInfo.Path, &SimpleHandler{c: c, rf: rf})

--- a/lnd/lnrpc/restrpc/websocket.go
+++ b/lnd/lnrpc/restrpc/websocket.go
@@ -97,7 +97,13 @@ func (conn *websocketConn) HandleJsonMessage(ctx *RpcContext, req []byte) {
 	//	log.Info("WebSocket JSon message received for endpoint: " + endpoint)
 
 	for _, rpcFunc := range rpcFunctions {
-		var commandInfo = help.CommandInfoData[rpcFunc.command]
+		var commandInfo help.CommandInfo
+
+		for _, commandInfo = range help.CommandInfoData {
+			if commandInfo.Command == rpcFunc.command {
+				break
+			}
+		}
 
 		if endpoint == commandInfo.Path {
 			var valueMessage protoiface.MessageV1 = nil
@@ -173,7 +179,13 @@ func (conn *websocketConn) HandleProtobufMessage(ctx *RpcContext, req []byte) {
 	//	log.Info("WebSocket Protobuf message received for endpoint: " + endpoint)
 
 	for _, rpcFunc := range rpcFunctions {
-		var commandInfo = help.CommandInfoData[rpcFunc.command]
+		var commandInfo help.CommandInfo
+
+		for _, commandInfo = range help.CommandInfoData {
+			if commandInfo.Command == rpcFunc.command {
+				break
+			}
+		}
 
 		if endpoint == commandInfo.Path {
 			var valueMessage protoiface.MessageV1 = nil

--- a/lnd/lnrpc/router.proto.doc.json
+++ b/lnd/lnrpc/router.proto.doc.json
@@ -1652,7 +1652,7 @@
           "methods": [
             {
               "name": "SendPaymentV2",
-              "description": "SendPaymentV2 attempts to route a payment described by the passed\nPaymentRequest to the final destination. The call returns a stream of\npayment updates.",
+              "description": "$pld.category: `Payment`\n$pld.short_description: `Send a payment over lightning`\n\nSendPaymentV2 attempts to route a payment described by the passed\nPaymentRequest to the final destination. The call returns a stream of\npayment updates.",
               "requestType": "SendPaymentRequest",
               "requestLongType": "SendPaymentRequest",
               "requestFullType": "routerrpc.SendPaymentRequest",
@@ -1664,7 +1664,7 @@
             },
             {
               "name": "TrackPaymentV2",
-              "description": "TrackPaymentV2 returns an update stream for the payment identified by the\npayment hash.",
+              "description": "$pld.category: `Payment`\n$pld.short_description: `Track payment`\n\nTrackPaymentV2 returns an update stream for the payment identified by the\npayment hash.",
               "requestType": "TrackPaymentRequest",
               "requestLongType": "TrackPaymentRequest",
               "requestFullType": "routerrpc.TrackPaymentRequest",
@@ -1703,7 +1703,7 @@
             },
             {
               "name": "SendToRouteV2",
-              "description": "SendToRouteV2 attempts to make a payment via the specified route. This\nmethod differs from SendPayment in that it allows users to specify a full\nroute manually. This can be used for things like rebalancing, and atomic\nswaps.",
+              "description": "$pld.category: `Payment`\n$pld.short_description: `Send a payment over a predefined route`\n\nSendToRouteV2 attempts to make a payment via the specified route. This\nmethod differs from SendPayment in that it allows users to specify a full\nroute manually. This can be used for things like rebalancing, and atomic\nswaps.",
               "requestType": "SendToRouteRequest",
               "requestLongType": "SendToRouteRequest",
               "requestFullType": "routerrpc.SendToRouteRequest",
@@ -1715,7 +1715,7 @@
             },
             {
               "name": "ResetMissionControl",
-              "description": "ResetMissionControl clears all mission control state and starts with a clean\nslate.",
+              "description": "$pld.category: `Payment`\n$pld.short_description: `Reset internal mission control state`\n\nResetMissionControl clears all mission control state and starts with a clean\nslate.",
               "requestType": "ResetMissionControlRequest",
               "requestLongType": "ResetMissionControlRequest",
               "requestFullType": "routerrpc.ResetMissionControlRequest",
@@ -1727,7 +1727,7 @@
             },
             {
               "name": "QueryMissionControl",
-              "description": "QueryMissionControl exposes the internal mission control state to callers.\nIt is a development feature.",
+              "description": "$pld.category: `Payment`\n$pld.short_description: `Query the internal mission control state`\n\nQueryMissionControl exposes the internal mission control state to callers.\nIt is a development feature.",
               "requestType": "QueryMissionControlRequest",
               "requestLongType": "QueryMissionControlRequest",
               "requestFullType": "routerrpc.QueryMissionControlRequest",
@@ -1739,7 +1739,7 @@
             },
             {
               "name": "QueryProbability",
-              "description": "QueryProbability returns the current success probability estimate for a\ngiven node pair and amount.",
+              "description": "$pld.category: `Payment`\n$pld.short_description: `Estimate a success probability`\n\nQueryProbability returns the current success probability estimate for a\ngiven node pair and amount.",
               "requestType": "QueryProbabilityRequest",
               "requestLongType": "QueryProbabilityRequest",
               "requestFullType": "routerrpc.QueryProbabilityRequest",
@@ -1751,7 +1751,7 @@
             },
             {
               "name": "BuildRoute",
-              "description": "BuildRoute builds a fully specified route based on a list of hop public\nkeys. It retrieves the relevant channel policies from the graph in order to\ncalculate the correct fees and time locks.",
+              "description": "$pld.category: `Payment`\n$pld.short_description: `Build a route from a list of hop pubkeys`\n\nBuildRoute builds a fully specified route based on a list of hop public\nkeys. It retrieves the relevant channel policies from the graph in order to\ncalculate the correct fees and time locks.",
               "requestType": "BuildRouteRequest",
               "requestLongType": "BuildRouteRequest",
               "requestFullType": "routerrpc.BuildRouteRequest",

--- a/lnd/lnrpc/routerrpc/router.proto
+++ b/lnd/lnrpc/routerrpc/router.proto
@@ -10,6 +10,9 @@ option go_package = "github.com/pkt-cash/pktd/lnd/lnrpc/routerrpc";
 // subsystem of the daemon.
 service Router {
     /*
+    $pld.category: `Payment`
+    $pld.short_description: `Send a payment over lightning`
+
     SendPaymentV2 attempts to route a payment described by the passed
     PaymentRequest to the final destination. The call returns a stream of
     payment updates.
@@ -17,6 +20,9 @@ service Router {
     rpc SendPaymentV2 (SendPaymentRequest) returns (stream lnrpc.Payment);
 
     /*
+    $pld.category: `Payment`
+    $pld.short_description: `Track payment`
+
     TrackPaymentV2 returns an update stream for the payment identified by the
     payment hash.
     */
@@ -40,6 +46,9 @@ service Router {
     }
 
     /*
+    $pld.category: `Payment`
+    $pld.short_description: `Send a payment over a predefined route`
+
     SendToRouteV2 attempts to make a payment via the specified route. This
     method differs from SendPayment in that it allows users to specify a full
     route manually. This can be used for things like rebalancing, and atomic
@@ -48,6 +57,9 @@ service Router {
     rpc SendToRouteV2 (SendToRouteRequest) returns (lnrpc.HTLCAttempt);
 
     /*
+    $pld.category: `Payment`
+    $pld.short_description: `Reset internal mission control state`
+
     ResetMissionControl clears all mission control state and starts with a clean
     slate.
     */
@@ -55,6 +67,9 @@ service Router {
         returns (ResetMissionControlResponse);
 
     /*
+    $pld.category: `Payment`
+    $pld.short_description: `Query the internal mission control state`
+
     QueryMissionControl exposes the internal mission control state to callers.
     It is a development feature.
     */
@@ -62,6 +77,9 @@ service Router {
         returns (QueryMissionControlResponse);
 
     /*
+    $pld.category: `Payment`
+    $pld.short_description: `Estimate a success probability`
+
     QueryProbability returns the current success probability estimate for a
     given node pair and amount.
     */
@@ -69,6 +87,9 @@ service Router {
         returns (QueryProbabilityResponse);
 
     /*
+    $pld.category: `Payment`
+    $pld.short_description: `Build a route from a list of hop pubkeys`
+
     BuildRoute builds a fully specified route based on a list of hop public
     keys. It retrieves the relevant channel policies from the graph in order to
     calculate the correct fees and time locks.

--- a/lnd/lnrpc/routerrpc/router_grpc.pb.go
+++ b/lnd/lnrpc/routerrpc/router_grpc.pb.go
@@ -20,10 +20,16 @@ const _ = grpc.SupportPackageIsVersion7
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type RouterClient interface {
 	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Send a payment over lightning`
+	//
 	//SendPaymentV2 attempts to route a payment described by the passed
 	//PaymentRequest to the final destination. The call returns a stream of
 	//payment updates.
 	SendPaymentV2(ctx context.Context, in *SendPaymentRequest, opts ...grpc.CallOption) (Router_SendPaymentV2Client, error)
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Track payment`
 	//
 	//TrackPaymentV2 returns an update stream for the payment identified by the
 	//payment hash.
@@ -41,23 +47,38 @@ type RouterClient interface {
 	//SendToRouteV2 in that it doesn't return the full HTLC information.
 	SendToRoute(ctx context.Context, in *SendToRouteRequest, opts ...grpc.CallOption) (*SendToRouteResponse, error)
 	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Send a payment over a predefined route`
+	//
 	//SendToRouteV2 attempts to make a payment via the specified route. This
 	//method differs from SendPayment in that it allows users to specify a full
 	//route manually. This can be used for things like rebalancing, and atomic
 	//swaps.
 	SendToRouteV2(ctx context.Context, in *SendToRouteRequest, opts ...grpc.CallOption) (*lnrpc.HTLCAttempt, error)
 	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Reset internal mission control state`
+	//
 	//ResetMissionControl clears all mission control state and starts with a clean
 	//slate.
 	ResetMissionControl(ctx context.Context, in *ResetMissionControlRequest, opts ...grpc.CallOption) (*ResetMissionControlResponse, error)
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Query the internal mission control state`
 	//
 	//QueryMissionControl exposes the internal mission control state to callers.
 	//It is a development feature.
 	QueryMissionControl(ctx context.Context, in *QueryMissionControlRequest, opts ...grpc.CallOption) (*QueryMissionControlResponse, error)
 	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Estimate a success probability`
+	//
 	//QueryProbability returns the current success probability estimate for a
 	//given node pair and amount.
 	QueryProbability(ctx context.Context, in *QueryProbabilityRequest, opts ...grpc.CallOption) (*QueryProbabilityResponse, error)
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Build a route from a list of hop pubkeys`
 	//
 	//BuildRoute builds a fully specified route based on a list of hop public
 	//keys. It retrieves the relevant channel policies from the graph in order to
@@ -357,10 +378,16 @@ func (x *routerHtlcInterceptorClient) Recv() (*ForwardHtlcInterceptRequest, erro
 // for forward compatibility
 type RouterServer interface {
 	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Send a payment over lightning`
+	//
 	//SendPaymentV2 attempts to route a payment described by the passed
 	//PaymentRequest to the final destination. The call returns a stream of
 	//payment updates.
 	SendPaymentV2(*SendPaymentRequest, Router_SendPaymentV2Server) error
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Track payment`
 	//
 	//TrackPaymentV2 returns an update stream for the payment identified by the
 	//payment hash.
@@ -378,23 +405,38 @@ type RouterServer interface {
 	//SendToRouteV2 in that it doesn't return the full HTLC information.
 	SendToRoute(context.Context, *SendToRouteRequest) (*SendToRouteResponse, error)
 	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Send a payment over a predefined route`
+	//
 	//SendToRouteV2 attempts to make a payment via the specified route. This
 	//method differs from SendPayment in that it allows users to specify a full
 	//route manually. This can be used for things like rebalancing, and atomic
 	//swaps.
 	SendToRouteV2(context.Context, *SendToRouteRequest) (*lnrpc.HTLCAttempt, error)
 	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Reset internal mission control state`
+	//
 	//ResetMissionControl clears all mission control state and starts with a clean
 	//slate.
 	ResetMissionControl(context.Context, *ResetMissionControlRequest) (*ResetMissionControlResponse, error)
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Query the internal mission control state`
 	//
 	//QueryMissionControl exposes the internal mission control state to callers.
 	//It is a development feature.
 	QueryMissionControl(context.Context, *QueryMissionControlRequest) (*QueryMissionControlResponse, error)
 	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Estimate a success probability`
+	//
 	//QueryProbability returns the current success probability estimate for a
 	//given node pair and amount.
 	QueryProbability(context.Context, *QueryProbabilityRequest) (*QueryProbabilityResponse, error)
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Build a route from a list of hop pubkeys`
 	//
 	//BuildRoute builds a fully specified route based on a list of hop public
 	//keys. It retrieves the relevant channel policies from the graph in order to

--- a/lnd/lnrpc/rpc.proto
+++ b/lnd/lnrpc/rpc.proto
@@ -35,8 +35,9 @@ service Lightning {
     rpc WalletBalance (WalletBalanceRequest) returns (WalletBalanceResponse);
 
     /*
-    $pld.category: `Wallet`
-    $pld.short_description: ``
+    $pld.category: `Address`
+    $pld.short_description: `Compute and display balances for each address in the wallet`
+
     GetAddressBalances returns the balance for each of the addresses in the wallet.
      */                                                                                              
      rpc GetAddressBalances (GetAddressBalancesRequest) returns (GetAddressBalancesResponse);
@@ -51,17 +52,19 @@ service Lightning {
     */
     rpc ChannelBalance (ChannelBalanceRequest) returns (ChannelBalanceResponse);
 
-    /* lncli: `listchaintxns`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
+    $pld.category: `Transaction`
+    $pld.short_description: `List transactions from the wallet`
+
     GetTransactions returns a list describing all the known transactions
     relevant to the wallet.
     */
     rpc GetTransactions (GetTransactionsRequest) returns (TransactionDetails);
 
-    /* lncli: `estimatefee`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
+    $pld.category: `Neutrino`
+    $pld.short_description: `Get fee estimates for sending bitcoin on-chain to multiple addresses`
+
     EstimateFee asks the chain backend to estimate the fee rate and total fees
     for a transaction that pays to multiple specified outputs.
 
@@ -72,9 +75,10 @@ service Lightning {
     */
     rpc EstimateFee (EstimateFeeRequest) returns (EstimateFeeResponse);
 
-    /* lncli: `sendcoins`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
+    $pld.category: `Transaction`
+    $pld.short_description: `Send bitcoin on-chain to an address`
+
     SendCoins executes a request to send coins to a particular address. Unlike
     SendMany, this RPC call only allows creating a single output at a time. If
     neither target_conf, or sat_per_byte are set, then the internal wallet will
@@ -84,8 +88,6 @@ service Lightning {
     rpc SendCoins (SendCoinsRequest) returns (SendCoinsResponse);
 
     /* lncli: `listunspent`
-    $pld.category: ``
-    $pld.short_description: ``
     Deprecated, use walletrpc.ListUnspent instead.
 
     ListUnspent returns a list of all utxos spendable by the wallet with a
@@ -94,8 +96,6 @@ service Lightning {
     rpc ListUnspent (ListUnspentRequest) returns (ListUnspentResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
     SubscribeTransactions creates a uni-directional stream from the server to
     the client in which any newly discovered transactions relevant to the
     wallet are sent over.
@@ -103,9 +103,10 @@ service Lightning {
     rpc SubscribeTransactions (GetTransactionsRequest)
         returns (stream Transaction);
 
-    /* lncli: `sendmany`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
+    $pld.category: `Transaction`
+    $pld.short_description: `Send bitcoin on-chain to multiple addresses`
+
     SendMany handles a request for a transaction that creates multiple specified
     outputs in parallel. If neither target_conf, or sat_per_byte are set, then
     the internal wallet will consult its fee model to determine a fee for the
@@ -113,59 +114,57 @@ service Lightning {
     */
     rpc SendMany (SendManyRequest) returns (SendManyResponse);
 
-    /* lncli: `newaddress`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
     NewAddress creates a new address under control of the local wallet.
     */
     rpc NewAddress (NewAddressRequest) returns (NewAddressResponse);
 
-    /* lncli: `signmessage`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
+    $pld.category: `Address`
+    $pld.short_description: `Signs a message using the private key of a payment address`
+
     SignMessage signs a message with this node's private key. The returned
     signature string is `zbase32` encoded and pubkey recoverable, meaning that
     only the message digest and signature are needed for verification.
     */
     rpc SignMessage (SignMessageRequest) returns (SignMessageResponse);
 
-    /* lncli: `connect`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
+    $pld.category: `Peer`
+    $pld.short_description: `Connect to a remote pld peer`
+
     ConnectPeer attempts to establish a connection to a remote peer. This is at
     the networking level, and is used for communication between nodes. This is
     distinct from establishing a channel with a peer.
     */
     rpc ConnectPeer (ConnectPeerRequest) returns (ConnectPeerResponse);
 
-    /* lncli: `disconnect`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
+    $pld.category: `Peer`
+    $pld.short_description: `Disconnect a remote pld peer identified by public key`
+
     DisconnectPeer attempts to disconnect one peer from another identified by a
     given pubKey. In the case that we currently have a pending or active channel
     with the target peer, then this action will be not be allowed.
     */
     rpc DisconnectPeer (DisconnectPeerRequest) returns (DisconnectPeerResponse);
 
-    /* lncli: `listpeers`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
+    $pld.category: `Peer`
+    $pld.short_description: `List all active, currently connected peers`
+
     ListPeers returns a verbose listing of all currently active peers.
     */
     rpc ListPeers (ListPeersRequest) returns (ListPeersResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
     SubscribePeerEvents creates a uni-directional stream from the server to
     the client in which any events relevant to the state of peers are sent
     over. Events include peers going online and offline.
     */
     rpc SubscribePeerEvents (PeerEventSubscription) returns (stream PeerEvent);
 
-    /* lncli: `getinfo`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
     GetInfo returns general information concerning the lightning node including
     it's identity pubkey, alias, the chains it is connected to, and information
     concerning the number of open+pending channels.
@@ -173,8 +172,6 @@ service Lightning {
     rpc GetInfo (GetInfoRequest) returns (GetInfoResponse);
 
     /** lncli: `getrecoveryinfo`
-    $pld.category: ``
-    $pld.short_description: ``
     GetRecoveryInfo returns information concerning the recovery mode including
     whether it's in a recovery mode, whether the recovery is finished, and the
     progress made so far.
@@ -246,8 +243,6 @@ service Lightning {
     rpc OpenChannel (OpenChannelRequest) returns (stream OpenStatusUpdate);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
     FundingStateStep is an advanced funding related call that allows the caller
     to either execute some preparatory steps for a funding workflow, or
     manually progress a funding workflow. The primary way a funding flow is
@@ -260,8 +255,6 @@ service Lightning {
     rpc FundingStateStep (FundingTransitionMsg) returns (FundingStateStepResp);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
     ChannelAcceptor dispatches a bi-directional streaming RPC in which
     OpenChannel requests are sent to the client and the client responds with
     a boolean that tells LND whether or not to accept the channel. This allows
@@ -369,8 +362,6 @@ service Lightning {
     rpc LookupInvoice (PaymentHash) returns (Invoice);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
     SubscribeInvoices returns a uni-directional stream (server -> client) for
     notifying the client of newly added/settled invoices. The caller can
     optionally specify the add_index and/or the settle_index. If the add_index
@@ -475,9 +466,10 @@ service Lightning {
     */
     rpc GetNetworkInfo (NetworkInfoRequest) returns (NetworkInfo);
 
-    /* lncli: `stop`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
+    $pld.category: `Meta`
+    $pld.short_description: `Stop and shutdown the daemon`
+
     StopDaemon will send a shutdown request to the interrupt handler, triggering
     a graceful shutdown of the daemon.
     */
@@ -494,9 +486,10 @@ service Lightning {
     rpc SubscribeChannelGraph (GraphTopologySubscription)
         returns (stream GraphTopologyUpdate);
 
-    /* lncli: `debuglevel`
-    $pld.category: ``
-    $pld.short_description: ``
+    /*
+    $pld.category: `Meta`
+    $pld.short_description: `Set the debug level`
+
     DebugLevel allows a caller to programmatically set the logging verbosity of
     lnd. The logging can be targeted according to a coarse daemon-wide logging
     level, or in a granular fashion to specify the logging for a target
@@ -601,99 +594,115 @@ service Lightning {
         returns (stream ChanBackupSnapshot);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Unspent`
+    $pld.short_description: `Scan over the chain to find any transactions which may not have been recorded in the wallet's database`
+
     Scan over the chain to find any transactions which may not have been recorded in the wallet's database*/
     rpc ReSync (ReSyncChainRequest) returns (ReSyncChainResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Unspent`
+    $pld.short_description: `Stop a re-synchronization job before it's completion`
+
     Stop a re-synchronization job before it's completion*/
     rpc StopReSync (StopReSyncRequest) returns (StopReSyncResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Wallet`
+    $pld.short_description: `Get the wallet seed words for this wallet`
+
     Get the wallet seed words for this wallet*/
     rpc GetWalletSeed (GetWalletSeedRequest) returns (GetWalletSeedResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Seed`
+    $pld.short_description: `Alter the passphrase which is used to encrypt a wallet seed`
+
     Change seed's passphrase */
     rpc ChangeSeedPassphrase (ChangeSeedPassphraseRequest) returns (ChangeSeedPassphraseResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Wallet`
+    $pld.short_description: `Get a secret seed`
+
     Get a secret seed which is generated using the wallet's private key, this can be used as a password for another application*/
     rpc GetSecret (GetSecretRequest) returns (GetSecretResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Address`
+    $pld.short_description: `Imports a WIF-encoded private key to the 'imported' account`
+
     Imports a WIF-encoded private key to the 'imported' account.*/
     rpc ImportPrivKey (ImportPrivKeyRequest) returns (ImportPrivKeyResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Address`
+    $pld.short_description: `Returns the private key in WIF encoding that controls some wallet address`
+
     Returns the private key in WIF encoding that controls some wallet address.*/
     rpc DumpPrivKey (DumpPrivKeyRequest) returns (DumpPrivKeyResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Lock`
+    $pld.short_description: `Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session`
+
     Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.*/
     rpc ListLockUnspent (ListLockUnspentRequest) returns (ListLockUnspentResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Lock`
+    $pld.short_description: `Locks or unlocks an unspent output`
+
     Locks or unlocks an unspent output*/
     rpc LockUnspent (LockUnspentRequest) returns (LockUnspentResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Transaction`
+    $pld.short_description: `Create a transaction but do not send it to the chain`
+
     Create a transaction but po not send it to the chain*/
     rpc CreateTransaction (CreateTransactionRequest) returns (CreateTransactionResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Address`
+    $pld.short_description: `Generates a new address`
+
     Generates and returns a new payment address*/
     rpc GetNewAddress (GetNewAddressRequest) returns (GetNewAddressResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Transaction`
+    $pld.short_description: `Returns a JSON object with details regarding a transaction relevant to this wallet`
+
     Returns a JSON object with details regarding a transaction relevant to this wallet.*/
     rpc GetTransaction (GetTransactionRequest) returns (GetTransactionResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Network Steward Vote`
+    $pld.short_description: `Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)`
+
     Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)*/
     rpc SetNetworkStewardVote (SetNetworkStewardVoteRequest) returns (SetNetworkStewardVoteResponse);
     
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Network Steward Vote`
+    $pld.short_description: `Find out how the wallet is currently configured to vote in a network steward election`
+
     Find out how the wallet is currently configured to vote in a network steward election*/
     rpc GetNetworkStewardVote (GetNetworkStewardVoteRequest) returns (GetNetworkStewardVoteResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
+    $pld.category: `Neutrino`
+    $pld.short_description: `Broadcast a transaction onchain`
+
     Broadcast a transaction*/
     rpc BcastTransaction (BcastTransactionRequest) returns (BcastTransactionResponse);
 
     /*
-    $pld.category: ``
-    $pld.short_description: ``
-    SendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.*/
+    $pld.category: `Transaction`
+    $pld.short_description: `Authors, signs, and sends a transaction that outputs some amount to a payment address`
+
+    SendFrom authors, signs, and sends a transaction that outputs some amount to a payment address.*/
     rpc SendFrom (SendFromRequest) returns (SendFromResponse);
 }
 

--- a/lnd/lnrpc/rpc.proto
+++ b/lnd/lnrpc/rpc.proto
@@ -24,19 +24,27 @@ option go_package = "github.com/pkt-cash/pktd/lnd/lnrpc";
 
 // Lightning is the main RPC server of the daemon.
 service Lightning {
-    /* lncli: `walletbalance`
+    /*
+    $pld.category: `Wallet`
+    $pld.short_description: `Compute and display the wallet's current balance`
+
     WalletBalance returns total unspent outputs(confirmed and unconfirmed), all
     confirmed unspent outputs and all unconfirmed unspent outputs under control
     of the wallet.
     */
     rpc WalletBalance (WalletBalanceRequest) returns (WalletBalanceResponse);
 
-    /* lncli: `getaddressbalances`
+    /*
+    $pld.category: `Wallet`
+    $pld.short_description: ``
     GetAddressBalances returns the balance for each of the addresses in the wallet.
      */                                                                                              
      rpc GetAddressBalances (GetAddressBalancesRequest) returns (GetAddressBalancesResponse);
 
-    /* lncli: `channelbalance`
+    /*
+    $pld.category: `Channel`
+    $pld.short_description: `Returns the sum of the total available channel balance across all open channels`
+
     ChannelBalance returns a report on the total funds across all open channels,
     categorized in local/remote, pending local/remote and unsettled local/remote
     balances.
@@ -44,12 +52,16 @@ service Lightning {
     rpc ChannelBalance (ChannelBalanceRequest) returns (ChannelBalanceResponse);
 
     /* lncli: `listchaintxns`
+    $pld.category: ``
+    $pld.short_description: ``
     GetTransactions returns a list describing all the known transactions
     relevant to the wallet.
     */
     rpc GetTransactions (GetTransactionsRequest) returns (TransactionDetails);
 
     /* lncli: `estimatefee`
+    $pld.category: ``
+    $pld.short_description: ``
     EstimateFee asks the chain backend to estimate the fee rate and total fees
     for a transaction that pays to multiple specified outputs.
 
@@ -61,6 +73,8 @@ service Lightning {
     rpc EstimateFee (EstimateFeeRequest) returns (EstimateFeeResponse);
 
     /* lncli: `sendcoins`
+    $pld.category: ``
+    $pld.short_description: ``
     SendCoins executes a request to send coins to a particular address. Unlike
     SendMany, this RPC call only allows creating a single output at a time. If
     neither target_conf, or sat_per_byte are set, then the internal wallet will
@@ -70,6 +84,8 @@ service Lightning {
     rpc SendCoins (SendCoinsRequest) returns (SendCoinsResponse);
 
     /* lncli: `listunspent`
+    $pld.category: ``
+    $pld.short_description: ``
     Deprecated, use walletrpc.ListUnspent instead.
 
     ListUnspent returns a list of all utxos spendable by the wallet with a
@@ -78,6 +94,8 @@ service Lightning {
     rpc ListUnspent (ListUnspentRequest) returns (ListUnspentResponse);
 
     /*
+    $pld.category: ``
+    $pld.short_description: ``
     SubscribeTransactions creates a uni-directional stream from the server to
     the client in which any newly discovered transactions relevant to the
     wallet are sent over.
@@ -86,6 +104,8 @@ service Lightning {
         returns (stream Transaction);
 
     /* lncli: `sendmany`
+    $pld.category: ``
+    $pld.short_description: ``
     SendMany handles a request for a transaction that creates multiple specified
     outputs in parallel. If neither target_conf, or sat_per_byte are set, then
     the internal wallet will consult its fee model to determine a fee for the
@@ -94,11 +114,15 @@ service Lightning {
     rpc SendMany (SendManyRequest) returns (SendManyResponse);
 
     /* lncli: `newaddress`
+    $pld.category: ``
+    $pld.short_description: ``
     NewAddress creates a new address under control of the local wallet.
     */
     rpc NewAddress (NewAddressRequest) returns (NewAddressResponse);
 
     /* lncli: `signmessage`
+    $pld.category: ``
+    $pld.short_description: ``
     SignMessage signs a message with this node's private key. The returned
     signature string is `zbase32` encoded and pubkey recoverable, meaning that
     only the message digest and signature are needed for verification.
@@ -106,6 +130,8 @@ service Lightning {
     rpc SignMessage (SignMessageRequest) returns (SignMessageResponse);
 
     /* lncli: `connect`
+    $pld.category: ``
+    $pld.short_description: ``
     ConnectPeer attempts to establish a connection to a remote peer. This is at
     the networking level, and is used for communication between nodes. This is
     distinct from establishing a channel with a peer.
@@ -113,6 +139,8 @@ service Lightning {
     rpc ConnectPeer (ConnectPeerRequest) returns (ConnectPeerResponse);
 
     /* lncli: `disconnect`
+    $pld.category: ``
+    $pld.short_description: ``
     DisconnectPeer attempts to disconnect one peer from another identified by a
     given pubKey. In the case that we currently have a pending or active channel
     with the target peer, then this action will be not be allowed.
@@ -120,11 +148,15 @@ service Lightning {
     rpc DisconnectPeer (DisconnectPeerRequest) returns (DisconnectPeerResponse);
 
     /* lncli: `listpeers`
+    $pld.category: ``
+    $pld.short_description: ``
     ListPeers returns a verbose listing of all currently active peers.
     */
     rpc ListPeers (ListPeersRequest) returns (ListPeersResponse);
 
     /*
+    $pld.category: ``
+    $pld.short_description: ``
     SubscribePeerEvents creates a uni-directional stream from the server to
     the client in which any events relevant to the state of peers are sent
     over. Events include peers going online and offline.
@@ -132,6 +164,8 @@ service Lightning {
     rpc SubscribePeerEvents (PeerEventSubscription) returns (stream PeerEvent);
 
     /* lncli: `getinfo`
+    $pld.category: ``
+    $pld.short_description: ``
     GetInfo returns general information concerning the lightning node including
     it's identity pubkey, alias, the chains it is connected to, and information
     concerning the number of open+pending channels.
@@ -139,6 +173,8 @@ service Lightning {
     rpc GetInfo (GetInfoRequest) returns (GetInfoResponse);
 
     /** lncli: `getrecoveryinfo`
+    $pld.category: ``
+    $pld.short_description: ``
     GetRecoveryInfo returns information concerning the recovery mode including
     whether it's in a recovery mode, whether the recovery is finished, and the
     progress made so far.
@@ -147,7 +183,10 @@ service Lightning {
         returns (GetRecoveryInfoResponse);
 
     // TODO(roasbeef): merge with below with bool?
-    /* lncli: `pendingchannels`
+    /*
+    $pld.category: `Channel`
+    $pld.short_description: `Display information pertaining to pending channels`
+
     PendingChannels returns a list of all the channels that are currently
     considered "pending". A channel is pending if it has finished the funding
     workflow and is waiting for confirmations for the funding txn, or is in the
@@ -156,7 +195,10 @@ service Lightning {
     rpc PendingChannels (PendingChannelsRequest)
         returns (PendingChannelsResponse);
 
-    /* lncli: `listchannels`
+    /*
+    $pld.category: `Channel`
+    $pld.short_description: `List all open channels`
+
     ListChannels returns a description of all the open channels that this node
     is a participant in.
     */
@@ -171,7 +213,10 @@ service Lightning {
     rpc SubscribeChannelEvents (ChannelEventSubscription)
         returns (stream ChannelEventUpdate);
 
-    /* lncli: `closedchannels`
+    /*
+    $pld.category: `Channel`
+    $pld.short_description: `List all closed channels`
+
     ClosedChannels returns a description of all the closed channels that
     this node was a participant in.
     */
@@ -185,7 +230,10 @@ service Lightning {
     */
     rpc OpenChannelSync (OpenChannelRequest) returns (ChannelPoint);
 
-    /* lncli: `openchannel`
+    /*
+    $pld.category: `Channel`
+    $pld.short_description: `Open a channel to a node or an existing peer`
+
     OpenChannel attempts to open a singly funded channel specified in the
     request to a remote peer. Users are able to specify a target number of
     blocks that the funding transaction should be confirmed in, or a manual fee
@@ -198,6 +246,8 @@ service Lightning {
     rpc OpenChannel (OpenChannelRequest) returns (stream OpenStatusUpdate);
 
     /*
+    $pld.category: ``
+    $pld.short_description: ``
     FundingStateStep is an advanced funding related call that allows the caller
     to either execute some preparatory steps for a funding workflow, or
     manually progress a funding workflow. The primary way a funding flow is
@@ -210,6 +260,8 @@ service Lightning {
     rpc FundingStateStep (FundingTransitionMsg) returns (FundingStateStepResp);
 
     /*
+    $pld.category: ``
+    $pld.short_description: ``
     ChannelAcceptor dispatches a bi-directional streaming RPC in which
     OpenChannel requests are sent to the client and the client responds with
     a boolean that tells LND whether or not to accept the channel. This allows
@@ -219,7 +271,10 @@ service Lightning {
     rpc ChannelAcceptor (stream ChannelAcceptResponse)
         returns (stream ChannelAcceptRequest);
 
-    /* lncli: `closechannel`
+    /*
+    $pld.category: `Channel`
+    $pld.short_description: `Close an existing channel`
+
     CloseChannel attempts to close an active channel identified by its channel
     outpoint (ChannelPoint). The actions of this method can additionally be
     augmented to attempt a force close after a timeout period in the case of an
@@ -230,7 +285,10 @@ service Lightning {
     */
     rpc CloseChannel (CloseChannelRequest) returns (stream CloseStatusUpdate);
 
-    /* lncli: `abandonchannel`
+    /*
+    $pld.category: `Channel`
+    $pld.short_description: `Abandons an existing channel`
+
     AbandonChannel removes all channel state from the database except for a
     close summary. This method can be used to get rid of permanently unusable
     channels due to bugs fixed in newer versions of lnd. This method can also be
@@ -240,7 +298,7 @@ service Lightning {
     */
     rpc AbandonChannel (AbandonChannelRequest) returns (AbandonChannelResponse);
 
-    /* lncli: `sendpayment`
+    /*
     Deprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a
     bi-directional streaming RPC for sending payments through the Lightning
     Network. A single RPC invocation creates a persistent bi-directional
@@ -276,14 +334,20 @@ service Lightning {
     */
     rpc SendToRouteSync (SendToRouteRequest) returns (SendResponse);
 
-    /* lncli: `addinvoice`
+    /*
+    $pld.category: `Invoice`
+    $pld.short_description: `Add a new invoice`
+
     AddInvoice attempts to add a new invoice to the invoice database. Any
     duplicated invoices are rejected, therefore all invoices *must* have a
     unique payment preimage.
     */
     rpc AddInvoice (Invoice) returns (AddInvoiceResponse);
 
-    /* lncli: `listinvoices`
+    /*
+    $pld.category: `Invoice`
+    $pld.short_description: `List all invoices currently stored within the database. Any active debug invoices are ignored`
+
     ListInvoices returns a list of all the invoices currently stored within the
     database. Any active debug invoices are ignored. It has full support for
     paginated responses, allowing users to query for specific invoices through
@@ -294,7 +358,10 @@ service Lightning {
     */
     rpc ListInvoices (ListInvoiceRequest) returns (ListInvoiceResponse);
 
-    /* lncli: `lookupinvoice`
+    /*
+    $pld.category: `Invoice`
+    $pld.short_description: `Lookup an existing invoice by its payment hash`
+
     LookupInvoice attempts to look up an invoice according to its payment hash.
     The passed payment hash *must* be exactly 32 bytes, if not, an error is
     returned.
@@ -302,6 +369,8 @@ service Lightning {
     rpc LookupInvoice (PaymentHash) returns (Invoice);
 
     /*
+    $pld.category: ``
+    $pld.short_description: ``
     SubscribeInvoices returns a uni-directional stream (server -> client) for
     notifying the client of newly added/settled invoices. The caller can
     optionally specify the add_index and/or the settle_index. If the add_index
@@ -314,14 +383,20 @@ service Lightning {
     */
     rpc SubscribeInvoices (InvoiceSubscription) returns (stream Invoice);
 
-    /* lncli: `decodepayreq`
+    /*
+    $pld.category: `Invoice`
+    $pld.short_description: `Decode a payment request`
+
     DecodePayReq takes an encoded payment request string and attempts to decode
     it, returning a full description of the conditions encoded within the
     payment request.
     */
     rpc DecodePayReq (PayReqString) returns (PayReq);
 
-    /* lncli: `listpayments`
+    /*
+    $pld.category: `Payment`
+    $pld.short_description: `List all outgoing payments`
+
     ListPayments returns a list of all outgoing payments.
     */
     rpc ListPayments (ListPaymentsRequest) returns (ListPaymentsResponse);
@@ -332,7 +407,10 @@ service Lightning {
     rpc DeleteAllPayments (DeleteAllPaymentsRequest)
         returns (DeleteAllPaymentsResponse);
 
-    /* lncli: `describegraph`
+    /*
+    $pld.category: `Graph`
+    $pld.short_description: `Describe the network graph`
+
     DescribeGraph returns a description of the latest graph state from the
     point of view of the node. The graph information is partitioned into two
     components: all the nodes/vertexes, and all the edges that connect the
@@ -342,13 +420,19 @@ service Lightning {
     */
     rpc DescribeGraph (ChannelGraphRequest) returns (ChannelGraph);
 
-    /* lncli: `getnodemetrics`
+    /*
+    $pld.category: `Graph`
+    $pld.short_description: `Get node metrics`
+
     GetNodeMetrics returns node metrics calculated from the graph. Currently
     the only supported metric is betweenness centrality of individual nodes.
     */
     rpc GetNodeMetrics (NodeMetricsRequest) returns (NodeMetricsResponse);
 
-    /* lncli: `getchaninfo`
+    /*
+    $pld.category: `Graph`
+    $pld.short_description: `Get the state of a channel`
+
     GetChanInfo returns the latest authenticated network announcement for the
     given channel identified by its channel ID: an 8-byte integer which
     uniquely identifies the location of transaction's funding output within the
@@ -356,13 +440,19 @@ service Lightning {
     */
     rpc GetChanInfo (ChanInfoRequest) returns (ChannelEdge);
 
-    /* lncli: `getnodeinfo`
+    /*
+    $pld.category: `Graph`
+    $pld.short_description: `Get information on a specific node`
+
     GetNodeInfo returns the latest advertised, aggregated, and authenticated
     channel information for the specified node identified by its public key.
     */
     rpc GetNodeInfo (NodeInfoRequest) returns (NodeInfo);
 
-    /* lncli: `queryroutes`
+    /*
+    $pld.category: `Payment`
+    $pld.short_description: `Query a route to a destination`
+
     QueryRoutes attempts to query the daemon's Channel Router for a possible
     route to a target destination capable of carrying a specific amount of
     satoshis. The returned route contains the full details required to craft and
@@ -376,13 +466,18 @@ service Lightning {
     */
     rpc QueryRoutes (QueryRoutesRequest) returns (QueryRoutesResponse);
 
-    /* lncli: `getnetworkinfo`
+    /*
+    $pld.category: `Channel`
+    $pld.short_description: `Get statistical information about the current state of the network`
+
     GetNetworkInfo returns some basic stats about the known channel graph from
     the point of view of the node.
     */
     rpc GetNetworkInfo (NetworkInfoRequest) returns (NetworkInfo);
 
     /* lncli: `stop`
+    $pld.category: ``
+    $pld.short_description: ``
     StopDaemon will send a shutdown request to the interrupt handler, triggering
     a graceful shutdown of the daemon.
     */
@@ -400,6 +495,8 @@ service Lightning {
         returns (stream GraphTopologyUpdate);
 
     /* lncli: `debuglevel`
+    $pld.category: ``
+    $pld.short_description: ``
     DebugLevel allows a caller to programmatically set the logging verbosity of
     lnd. The logging can be targeted according to a coarse daemon-wide logging
     level, or in a granular fashion to specify the logging for a target
@@ -407,20 +504,29 @@ service Lightning {
     */
     rpc DebugLevel (DebugLevelRequest) returns (DebugLevelResponse);
 
-    /* lncli: `feereport`
+    /*
+    $pld.category: `Channel`
+    $pld.short_description: `Display the current fee policies of all active channels`
+
     FeeReport allows the caller to obtain a report detailing the current fee
     schedule enforced by the node globally for each channel.
     */
     rpc FeeReport (FeeReportRequest) returns (FeeReportResponse);
 
-    /* lncli: `updatechanpolicy`
+    /*
+    $pld.category: `Channel`
+    $pld.short_description: `Update the channel policy for all channels, or a single channel`
+
     UpdateChannelPolicy allows the caller to update the fee schedule and
     channel policies for all channels globally, or a particular channel.
     */
     rpc UpdateChannelPolicy (PolicyUpdateRequest)
         returns (PolicyUpdateResponse);
 
-    /* lncli: `fwdinghistory`
+    /*
+    $pld.category: `Payment`
+    $pld.short_description: `Query the history of all forwarded HTLCs`
+
     ForwardingHistory allows the caller to query the htlcswitch for a record of
     all HTLCs forwarded within the target time range, and integer offset
     within that time range. If no time-range is specified, then the first chunk
@@ -435,7 +541,10 @@ service Lightning {
     rpc ForwardingHistory (ForwardingHistoryRequest)
         returns (ForwardingHistoryResponse);
 
-    /* lncli: `exportchanbackup`
+    /*
+    $pld.category: `Backup`
+    $pld.short_description: `Obtain a static channel back up for a selected channels, or all known channels`
+
     ExportChannelBackup attempts to return an encrypted static channel backup
     for the target channel identified by it channel point. The backup is
     encrypted with a key generated from the aezeed seed of the user. The
@@ -457,6 +566,9 @@ service Lightning {
         returns (ChanBackupSnapshot);
 
     /*
+    $pld.category: `Backup`
+    $pld.short_description: `Verify an existing channel backup`
+
     VerifyChanBackup allows a caller to verify the integrity of a channel backup
     snapshot. This method will accept either a packed Single or a packed Multi.
     Specifying both will result in an error.
@@ -464,7 +576,10 @@ service Lightning {
     rpc VerifyChanBackup (ChanBackupSnapshot)
         returns (VerifyChanBackupResponse);
 
-    /* lncli: `restorechanbackup`
+    /*
+    $pld.category: `Backup`
+    $pld.short_description: `Restore an existing single or multi-channel static channel backup`
+
     RestoreChannelBackups accepts a set of singular channel backups, or a
     single encrypted multi-chan backup and attempts to recover any funds
     remaining within the channel. If we are able to unpack the backup, then the
@@ -485,52 +600,100 @@ service Lightning {
     rpc SubscribeChannelBackups (ChannelBackupSubscription)
         returns (stream ChanBackupSnapshot);
 
-    /*Scan over the chain to find any transactions which may not have been recorded in the wallet's database*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Scan over the chain to find any transactions which may not have been recorded in the wallet's database*/
     rpc ReSync (ReSyncChainRequest) returns (ReSyncChainResponse);
 
-    /*Stop a re-synchronization job before it's completion*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Stop a re-synchronization job before it's completion*/
     rpc StopReSync (StopReSyncRequest) returns (StopReSyncResponse);
 
-    /*Get the wallet seed words for this wallet*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Get the wallet seed words for this wallet*/
     rpc GetWalletSeed (GetWalletSeedRequest) returns (GetWalletSeedResponse);
 
-    /*  Change seed's passphrase */
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Change seed's passphrase */
     rpc ChangeSeedPassphrase (ChangeSeedPassphraseRequest) returns (ChangeSeedPassphraseResponse);
 
-    /*Get a secret seed which is generated using the wallet's private key, this can be used as a password for another application*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Get a secret seed which is generated using the wallet's private key, this can be used as a password for another application*/
     rpc GetSecret (GetSecretRequest) returns (GetSecretResponse);
 
-    /*Imports a WIF-encoded private key to the 'imported' account.*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Imports a WIF-encoded private key to the 'imported' account.*/
     rpc ImportPrivKey (ImportPrivKeyRequest) returns (ImportPrivKeyResponse);
 
-    /*Returns the private key in WIF encoding that controls some wallet address.*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Returns the private key in WIF encoding that controls some wallet address.*/
     rpc DumpPrivKey (DumpPrivKeyRequest) returns (DumpPrivKeyResponse);
 
-    /*Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.*/
     rpc ListLockUnspent (ListLockUnspentRequest) returns (ListLockUnspentResponse);
 
-    /*Locks or unlocks an unspent output*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Locks or unlocks an unspent output*/
     rpc LockUnspent (LockUnspentRequest) returns (LockUnspentResponse);
 
-    /*Create a transaction but po not send it to the chain*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Create a transaction but po not send it to the chain*/
     rpc CreateTransaction (CreateTransactionRequest) returns (CreateTransactionResponse);
 
-    /*Generates and returns a new payment address*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Generates and returns a new payment address*/
     rpc GetNewAddress (GetNewAddressRequest) returns (GetNewAddressResponse);
 
-    /*Returns a JSON object with details regarding a transaction relevant to this wallet.*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Returns a JSON object with details regarding a transaction relevant to this wallet.*/
     rpc GetTransaction (GetTransactionRequest) returns (GetTransactionResponse);
 
-    /*Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)*/
     rpc SetNetworkStewardVote (SetNetworkStewardVoteRequest) returns (SetNetworkStewardVoteResponse);
     
-    /*Find out how the wallet is currently configured to vote in a network steward election*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Find out how the wallet is currently configured to vote in a network steward election*/
     rpc GetNetworkStewardVote (GetNetworkStewardVoteRequest) returns (GetNetworkStewardVoteResponse);
 
-    /*Broadcast a transaction*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    Broadcast a transaction*/
     rpc BcastTransaction (BcastTransactionRequest) returns (BcastTransactionResponse);
 
-    /*SendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.*/
+    /*
+    $pld.category: ``
+    $pld.short_description: ``
+    SendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.*/
     rpc SendFrom (SendFromRequest) returns (SendFromResponse);
 }
 

--- a/lnd/lnrpc/rpc.proto.doc.json
+++ b/lnd/lnrpc/rpc.proto.doc.json
@@ -12071,7 +12071,7 @@
             },
             {
               "name": "GetAddressBalances",
-              "description": "$pld.category: `Wallet`\n$pld.short_description: ``\nGetAddressBalances returns the balance for each of the addresses in the wallet.",
+              "description": "$pld.category: `Address`\n$pld.short_description: `Compute and display balances for each address in the wallet`\n\nGetAddressBalances returns the balance for each of the addresses in the wallet.",
               "requestType": "GetAddressBalancesRequest",
               "requestLongType": "GetAddressBalancesRequest",
               "requestFullType": "lnrpc.GetAddressBalancesRequest",
@@ -12095,7 +12095,7 @@
             },
             {
               "name": "GetTransactions",
-              "description": "lncli: `listchaintxns`\n$pld.category: ``\n$pld.short_description: ``\nGetTransactions returns a list describing all the known transactions\nrelevant to the wallet.",
+              "description": "$pld.category: `Transaction`\n$pld.short_description: `List transactions from the wallet`\n\nGetTransactions returns a list describing all the known transactions\nrelevant to the wallet.",
               "requestType": "GetTransactionsRequest",
               "requestLongType": "GetTransactionsRequest",
               "requestFullType": "lnrpc.GetTransactionsRequest",
@@ -12107,7 +12107,7 @@
             },
             {
               "name": "EstimateFee",
-              "description": "lncli: `estimatefee`\n$pld.category: ``\n$pld.short_description: ``\nEstimateFee asks the chain backend to estimate the fee rate and total fees\nfor a transaction that pays to multiple specified outputs.\n\nWhen using REST, the `AddrToAmount` map type can be set by appending\n`\u0026AddrToAmount[\u003caddress\u003e]=\u003camount_to_send\u003e` to the URL. Unfortunately this\nmap type doesn't appear in the REST API documentation because of a bug in\nthe grpc-gateway library.",
+              "description": "$pld.category: `Neutrino`\n$pld.short_description: `Get fee estimates for sending bitcoin on-chain to multiple addresses`\n\nEstimateFee asks the chain backend to estimate the fee rate and total fees\nfor a transaction that pays to multiple specified outputs.\n\nWhen using REST, the `AddrToAmount` map type can be set by appending\n`\u0026AddrToAmount[\u003caddress\u003e]=\u003camount_to_send\u003e` to the URL. Unfortunately this\nmap type doesn't appear in the REST API documentation because of a bug in\nthe grpc-gateway library.",
               "requestType": "EstimateFeeRequest",
               "requestLongType": "EstimateFeeRequest",
               "requestFullType": "lnrpc.EstimateFeeRequest",
@@ -12119,7 +12119,7 @@
             },
             {
               "name": "SendCoins",
-              "description": "lncli: `sendcoins`\n$pld.category: ``\n$pld.short_description: ``\nSendCoins executes a request to send coins to a particular address. Unlike\nSendMany, this RPC call only allows creating a single output at a time. If\nneither target_conf, or sat_per_byte are set, then the internal wallet will\nconsult its fee model to determine a fee for the default confirmation\ntarget.",
+              "description": "$pld.category: `Transaction`\n$pld.short_description: `Send bitcoin on-chain to an address`\n\nSendCoins executes a request to send coins to a particular address. Unlike\nSendMany, this RPC call only allows creating a single output at a time. If\nneither target_conf, or sat_per_byte are set, then the internal wallet will\nconsult its fee model to determine a fee for the default confirmation\ntarget.",
               "requestType": "SendCoinsRequest",
               "requestLongType": "SendCoinsRequest",
               "requestFullType": "lnrpc.SendCoinsRequest",
@@ -12131,7 +12131,7 @@
             },
             {
               "name": "ListUnspent",
-              "description": "lncli: `listunspent`\n$pld.category: ``\n$pld.short_description: ``\nDeprecated, use walletrpc.ListUnspent instead.\n\nListUnspent returns a list of all utxos spendable by the wallet with a\nnumber of confirmations between the specified minimum and maximum.",
+              "description": "lncli: `listunspent`\nDeprecated, use walletrpc.ListUnspent instead.\n\nListUnspent returns a list of all utxos spendable by the wallet with a\nnumber of confirmations between the specified minimum and maximum.",
               "requestType": "ListUnspentRequest",
               "requestLongType": "ListUnspentRequest",
               "requestFullType": "lnrpc.ListUnspentRequest",
@@ -12143,7 +12143,7 @@
             },
             {
               "name": "SubscribeTransactions",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nSubscribeTransactions creates a uni-directional stream from the server to\nthe client in which any newly discovered transactions relevant to the\nwallet are sent over.",
+              "description": "SubscribeTransactions creates a uni-directional stream from the server to\nthe client in which any newly discovered transactions relevant to the\nwallet are sent over.",
               "requestType": "GetTransactionsRequest",
               "requestLongType": "GetTransactionsRequest",
               "requestFullType": "lnrpc.GetTransactionsRequest",
@@ -12155,7 +12155,7 @@
             },
             {
               "name": "SendMany",
-              "description": "lncli: `sendmany`\n$pld.category: ``\n$pld.short_description: ``\nSendMany handles a request for a transaction that creates multiple specified\noutputs in parallel. If neither target_conf, or sat_per_byte are set, then\nthe internal wallet will consult its fee model to determine a fee for the\ndefault confirmation target.",
+              "description": "$pld.category: `Transaction`\n$pld.short_description: `Send bitcoin on-chain to multiple addresses`\n\nSendMany handles a request for a transaction that creates multiple specified\noutputs in parallel. If neither target_conf, or sat_per_byte are set, then\nthe internal wallet will consult its fee model to determine a fee for the\ndefault confirmation target.",
               "requestType": "SendManyRequest",
               "requestLongType": "SendManyRequest",
               "requestFullType": "lnrpc.SendManyRequest",
@@ -12167,7 +12167,7 @@
             },
             {
               "name": "NewAddress",
-              "description": "lncli: `newaddress`\n$pld.category: ``\n$pld.short_description: ``\nNewAddress creates a new address under control of the local wallet.",
+              "description": "NewAddress creates a new address under control of the local wallet.",
               "requestType": "NewAddressRequest",
               "requestLongType": "NewAddressRequest",
               "requestFullType": "lnrpc.NewAddressRequest",
@@ -12179,7 +12179,7 @@
             },
             {
               "name": "SignMessage",
-              "description": "lncli: `signmessage`\n$pld.category: ``\n$pld.short_description: ``\nSignMessage signs a message with this node's private key. The returned\nsignature string is `zbase32` encoded and pubkey recoverable, meaning that\nonly the message digest and signature are needed for verification.",
+              "description": "$pld.category: `Address`\n$pld.short_description: `Signs a message using the private key of a payment address`\n\nSignMessage signs a message with this node's private key. The returned\nsignature string is `zbase32` encoded and pubkey recoverable, meaning that\nonly the message digest and signature are needed for verification.",
               "requestType": "SignMessageRequest",
               "requestLongType": "SignMessageRequest",
               "requestFullType": "lnrpc.SignMessageRequest",
@@ -12191,7 +12191,7 @@
             },
             {
               "name": "ConnectPeer",
-              "description": "lncli: `connect`\n$pld.category: ``\n$pld.short_description: ``\nConnectPeer attempts to establish a connection to a remote peer. This is at\nthe networking level, and is used for communication between nodes. This is\ndistinct from establishing a channel with a peer.",
+              "description": "$pld.category: `Peer`\n$pld.short_description: `Connect to a remote pld peer`\n\nConnectPeer attempts to establish a connection to a remote peer. This is at\nthe networking level, and is used for communication between nodes. This is\ndistinct from establishing a channel with a peer.",
               "requestType": "ConnectPeerRequest",
               "requestLongType": "ConnectPeerRequest",
               "requestFullType": "lnrpc.ConnectPeerRequest",
@@ -12203,7 +12203,7 @@
             },
             {
               "name": "DisconnectPeer",
-              "description": "lncli: `disconnect`\n$pld.category: ``\n$pld.short_description: ``\nDisconnectPeer attempts to disconnect one peer from another identified by a\ngiven pubKey. In the case that we currently have a pending or active channel\nwith the target peer, then this action will be not be allowed.",
+              "description": "$pld.category: `Peer`\n$pld.short_description: `Disconnect a remote pld peer identified by public key`\n\nDisconnectPeer attempts to disconnect one peer from another identified by a\ngiven pubKey. In the case that we currently have a pending or active channel\nwith the target peer, then this action will be not be allowed.",
               "requestType": "DisconnectPeerRequest",
               "requestLongType": "DisconnectPeerRequest",
               "requestFullType": "lnrpc.DisconnectPeerRequest",
@@ -12215,7 +12215,7 @@
             },
             {
               "name": "ListPeers",
-              "description": "lncli: `listpeers`\n$pld.category: ``\n$pld.short_description: ``\nListPeers returns a verbose listing of all currently active peers.",
+              "description": "$pld.category: `Peer`\n$pld.short_description: `List all active, currently connected peers`\n\nListPeers returns a verbose listing of all currently active peers.",
               "requestType": "ListPeersRequest",
               "requestLongType": "ListPeersRequest",
               "requestFullType": "lnrpc.ListPeersRequest",
@@ -12227,7 +12227,7 @@
             },
             {
               "name": "SubscribePeerEvents",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nSubscribePeerEvents creates a uni-directional stream from the server to\nthe client in which any events relevant to the state of peers are sent\nover. Events include peers going online and offline.",
+              "description": "SubscribePeerEvents creates a uni-directional stream from the server to\nthe client in which any events relevant to the state of peers are sent\nover. Events include peers going online and offline.",
               "requestType": "PeerEventSubscription",
               "requestLongType": "PeerEventSubscription",
               "requestFullType": "lnrpc.PeerEventSubscription",
@@ -12239,7 +12239,7 @@
             },
             {
               "name": "GetInfo",
-              "description": "lncli: `getinfo`\n$pld.category: ``\n$pld.short_description: ``\nGetInfo returns general information concerning the lightning node including\nit's identity pubkey, alias, the chains it is connected to, and information\nconcerning the number of open+pending channels.",
+              "description": "GetInfo returns general information concerning the lightning node including\nit's identity pubkey, alias, the chains it is connected to, and information\nconcerning the number of open+pending channels.",
               "requestType": "GetInfoRequest",
               "requestLongType": "GetInfoRequest",
               "requestFullType": "lnrpc.GetInfoRequest",
@@ -12251,7 +12251,7 @@
             },
             {
               "name": "GetRecoveryInfo",
-              "description": "lncli: `getrecoveryinfo`\n$pld.category: ``\n$pld.short_description: ``\nGetRecoveryInfo returns information concerning the recovery mode including\nwhether it's in a recovery mode, whether the recovery is finished, and the\nprogress made so far.",
+              "description": "lncli: `getrecoveryinfo`\nGetRecoveryInfo returns information concerning the recovery mode including\nwhether it's in a recovery mode, whether the recovery is finished, and the\nprogress made so far.",
               "requestType": "GetRecoveryInfoRequest",
               "requestLongType": "GetRecoveryInfoRequest",
               "requestFullType": "lnrpc.GetRecoveryInfoRequest",
@@ -12335,7 +12335,7 @@
             },
             {
               "name": "FundingStateStep",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nFundingStateStep is an advanced funding related call that allows the caller\nto either execute some preparatory steps for a funding workflow, or\nmanually progress a funding workflow. The primary way a funding flow is\nidentified is via its pending channel ID. As an example, this method can be\nused to specify that we're expecting a funding flow for a particular\npending channel ID, for which we need to use specific parameters.\nAlternatively, this can be used to interactively drive PSBT signing for\nfunding for partially complete funding transactions.",
+              "description": "FundingStateStep is an advanced funding related call that allows the caller\nto either execute some preparatory steps for a funding workflow, or\nmanually progress a funding workflow. The primary way a funding flow is\nidentified is via its pending channel ID. As an example, this method can be\nused to specify that we're expecting a funding flow for a particular\npending channel ID, for which we need to use specific parameters.\nAlternatively, this can be used to interactively drive PSBT signing for\nfunding for partially complete funding transactions.",
               "requestType": "FundingTransitionMsg",
               "requestLongType": "FundingTransitionMsg",
               "requestFullType": "lnrpc.FundingTransitionMsg",
@@ -12347,7 +12347,7 @@
             },
             {
               "name": "ChannelAcceptor",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nChannelAcceptor dispatches a bi-directional streaming RPC in which\nOpenChannel requests are sent to the client and the client responds with\na boolean that tells LND whether or not to accept the channel. This allows\nnode operators to specify their own criteria for accepting inbound channels\nthrough a single persistent connection.",
+              "description": "ChannelAcceptor dispatches a bi-directional streaming RPC in which\nOpenChannel requests are sent to the client and the client responds with\na boolean that tells LND whether or not to accept the channel. This allows\nnode operators to specify their own criteria for accepting inbound channels\nthrough a single persistent connection.",
               "requestType": "ChannelAcceptResponse",
               "requestLongType": "ChannelAcceptResponse",
               "requestFullType": "lnrpc.ChannelAcceptResponse",
@@ -12473,7 +12473,7 @@
             },
             {
               "name": "SubscribeInvoices",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nSubscribeInvoices returns a uni-directional stream (server -\u003e client) for\nnotifying the client of newly added/settled invoices. The caller can\noptionally specify the add_index and/or the settle_index. If the add_index\nis specified, then we'll first start by sending add invoice events for all\ninvoices with an add_index greater than the specified value. If the\nsettle_index is specified, the next, we'll send out all settle events for\ninvoices with a settle_index greater than the specified value. One or both\nof these fields can be set. If no fields are set, then we'll only send out\nthe latest add/settle events.",
+              "description": "SubscribeInvoices returns a uni-directional stream (server -\u003e client) for\nnotifying the client of newly added/settled invoices. The caller can\noptionally specify the add_index and/or the settle_index. If the add_index\nis specified, then we'll first start by sending add invoice events for all\ninvoices with an add_index greater than the specified value. If the\nsettle_index is specified, the next, we'll send out all settle events for\ninvoices with a settle_index greater than the specified value. One or both\nof these fields can be set. If no fields are set, then we'll only send out\nthe latest add/settle events.",
               "requestType": "InvoiceSubscription",
               "requestLongType": "InvoiceSubscription",
               "requestFullType": "lnrpc.InvoiceSubscription",
@@ -12593,7 +12593,7 @@
             },
             {
               "name": "StopDaemon",
-              "description": "lncli: `stop`\n$pld.category: ``\n$pld.short_description: ``\nStopDaemon will send a shutdown request to the interrupt handler, triggering\na graceful shutdown of the daemon.",
+              "description": "$pld.category: `Meta`\n$pld.short_description: `Stop and shutdown the daemon`\n\nStopDaemon will send a shutdown request to the interrupt handler, triggering\na graceful shutdown of the daemon.",
               "requestType": "StopRequest",
               "requestLongType": "StopRequest",
               "requestFullType": "lnrpc.StopRequest",
@@ -12617,7 +12617,7 @@
             },
             {
               "name": "DebugLevel",
-              "description": "lncli: `debuglevel`\n$pld.category: ``\n$pld.short_description: ``\nDebugLevel allows a caller to programmatically set the logging verbosity of\nlnd. The logging can be targeted according to a coarse daemon-wide logging\nlevel, or in a granular fashion to specify the logging for a target\nsub-system.",
+              "description": "$pld.category: `Meta`\n$pld.short_description: `Set the debug level`\n\nDebugLevel allows a caller to programmatically set the logging verbosity of\nlnd. The logging can be targeted according to a coarse daemon-wide logging\nlevel, or in a granular fashion to specify the logging for a target\nsub-system.",
               "requestType": "DebugLevelRequest",
               "requestLongType": "DebugLevelRequest",
               "requestFullType": "lnrpc.DebugLevelRequest",
@@ -12725,7 +12725,7 @@
             },
             {
               "name": "ReSync",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nScan over the chain to find any transactions which may not have been recorded in the wallet's database",
+              "description": "$pld.category: `Unspent`\n$pld.short_description: `Scan over the chain to find any transactions which may not have been recorded in the wallet's database`\n\nScan over the chain to find any transactions which may not have been recorded in the wallet's database",
               "requestType": "ReSyncChainRequest",
               "requestLongType": "ReSyncChainRequest",
               "requestFullType": "lnrpc.ReSyncChainRequest",
@@ -12737,7 +12737,7 @@
             },
             {
               "name": "StopReSync",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nStop a re-synchronization job before it's completion",
+              "description": "$pld.category: `Unspent`\n$pld.short_description: `Stop a re-synchronization job before it's completion`\n\nStop a re-synchronization job before it's completion",
               "requestType": "StopReSyncRequest",
               "requestLongType": "StopReSyncRequest",
               "requestFullType": "lnrpc.StopReSyncRequest",
@@ -12749,7 +12749,7 @@
             },
             {
               "name": "GetWalletSeed",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nGet the wallet seed words for this wallet",
+              "description": "$pld.category: `Wallet`\n$pld.short_description: `Get the wallet seed words for this wallet`\n\nGet the wallet seed words for this wallet",
               "requestType": "GetWalletSeedRequest",
               "requestLongType": "GetWalletSeedRequest",
               "requestFullType": "lnrpc.GetWalletSeedRequest",
@@ -12761,7 +12761,7 @@
             },
             {
               "name": "ChangeSeedPassphrase",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nChange seed's passphrase",
+              "description": "$pld.category: `Seed`\n$pld.short_description: `Alter the passphrase which is used to encrypt a wallet seed`\n\nChange seed's passphrase",
               "requestType": "ChangeSeedPassphraseRequest",
               "requestLongType": "ChangeSeedPassphraseRequest",
               "requestFullType": "lnrpc.ChangeSeedPassphraseRequest",
@@ -12773,7 +12773,7 @@
             },
             {
               "name": "GetSecret",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nGet a secret seed which is generated using the wallet's private key, this can be used as a password for another application",
+              "description": "$pld.category: `Wallet`\n$pld.short_description: `Get a secret seed`\n\nGet a secret seed which is generated using the wallet's private key, this can be used as a password for another application",
               "requestType": "GetSecretRequest",
               "requestLongType": "GetSecretRequest",
               "requestFullType": "lnrpc.GetSecretRequest",
@@ -12785,7 +12785,7 @@
             },
             {
               "name": "ImportPrivKey",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nImports a WIF-encoded private key to the 'imported' account.",
+              "description": "$pld.category: `Address`\n$pld.short_description: `Imports a WIF-encoded private key to the 'imported' account`\n\nImports a WIF-encoded private key to the 'imported' account.",
               "requestType": "ImportPrivKeyRequest",
               "requestLongType": "ImportPrivKeyRequest",
               "requestFullType": "lnrpc.ImportPrivKeyRequest",
@@ -12797,7 +12797,7 @@
             },
             {
               "name": "DumpPrivKey",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nReturns the private key in WIF encoding that controls some wallet address.",
+              "description": "$pld.category: `Address`\n$pld.short_description: `Returns the private key in WIF encoding that controls some wallet address`\n\nReturns the private key in WIF encoding that controls some wallet address.",
               "requestType": "DumpPrivKeyRequest",
               "requestLongType": "DumpPrivKeyRequest",
               "requestFullType": "lnrpc.DumpPrivKeyRequest",
@@ -12809,7 +12809,7 @@
             },
             {
               "name": "ListLockUnspent",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nReturns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.",
+              "description": "$pld.category: `Lock`\n$pld.short_description: `Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session`\n\nReturns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.",
               "requestType": "ListLockUnspentRequest",
               "requestLongType": "ListLockUnspentRequest",
               "requestFullType": "lnrpc.ListLockUnspentRequest",
@@ -12821,7 +12821,7 @@
             },
             {
               "name": "LockUnspent",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nLocks or unlocks an unspent output",
+              "description": "$pld.category: `Lock`\n$pld.short_description: `Locks or unlocks an unspent output`\n\nLocks or unlocks an unspent output",
               "requestType": "LockUnspentRequest",
               "requestLongType": "LockUnspentRequest",
               "requestFullType": "lnrpc.LockUnspentRequest",
@@ -12833,7 +12833,7 @@
             },
             {
               "name": "CreateTransaction",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nCreate a transaction but po not send it to the chain",
+              "description": "$pld.category: `Transaction`\n$pld.short_description: `Create a transaction but do not send it to the chain`\n\nCreate a transaction but po not send it to the chain",
               "requestType": "CreateTransactionRequest",
               "requestLongType": "CreateTransactionRequest",
               "requestFullType": "lnrpc.CreateTransactionRequest",
@@ -12845,7 +12845,7 @@
             },
             {
               "name": "GetNewAddress",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nGenerates and returns a new payment address",
+              "description": "$pld.category: `Address`\n$pld.short_description: `Generates a new address`\n\nGenerates and returns a new payment address",
               "requestType": "GetNewAddressRequest",
               "requestLongType": "GetNewAddressRequest",
               "requestFullType": "lnrpc.GetNewAddressRequest",
@@ -12857,7 +12857,7 @@
             },
             {
               "name": "GetTransaction",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nReturns a JSON object with details regarding a transaction relevant to this wallet.",
+              "description": "$pld.category: `Transaction`\n$pld.short_description: `Returns a JSON object with details regarding a transaction relevant to this wallet`\n\nReturns a JSON object with details regarding a transaction relevant to this wallet.",
               "requestType": "GetTransactionRequest",
               "requestLongType": "GetTransactionRequest",
               "requestFullType": "lnrpc.GetTransactionRequest",
@@ -12869,7 +12869,7 @@
             },
             {
               "name": "SetNetworkStewardVote",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nConfigure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)",
+              "description": "$pld.category: `Network Steward Vote`\n$pld.short_description: `Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)`\n\nConfigure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)",
               "requestType": "SetNetworkStewardVoteRequest",
               "requestLongType": "SetNetworkStewardVoteRequest",
               "requestFullType": "lnrpc.SetNetworkStewardVoteRequest",
@@ -12881,7 +12881,7 @@
             },
             {
               "name": "GetNetworkStewardVote",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nFind out how the wallet is currently configured to vote in a network steward election",
+              "description": "$pld.category: `Network Steward Vote`\n$pld.short_description: `Find out how the wallet is currently configured to vote in a network steward election`\n\nFind out how the wallet is currently configured to vote in a network steward election",
               "requestType": "GetNetworkStewardVoteRequest",
               "requestLongType": "GetNetworkStewardVoteRequest",
               "requestFullType": "lnrpc.GetNetworkStewardVoteRequest",
@@ -12893,7 +12893,7 @@
             },
             {
               "name": "BcastTransaction",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nBroadcast a transaction",
+              "description": "$pld.category: `Neutrino`\n$pld.short_description: `Broadcast a transaction onchain`\n\nBroadcast a transaction",
               "requestType": "BcastTransactionRequest",
               "requestLongType": "BcastTransactionRequest",
               "requestFullType": "lnrpc.BcastTransactionRequest",
@@ -12905,7 +12905,7 @@
             },
             {
               "name": "SendFrom",
-              "description": "$pld.category: ``\n$pld.short_description: ``\nSendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.",
+              "description": "$pld.category: `Transaction`\n$pld.short_description: `Authors, signs, and sends a transaction that outputs some amount to a payment address`\n\nSendFrom authors, signs, and sends a transaction that outputs some amount to a payment address.",
               "requestType": "SendFromRequest",
               "requestLongType": "SendFromRequest",
               "requestFullType": "lnrpc.SendFromRequest",

--- a/lnd/lnrpc/rpc.proto.doc.json
+++ b/lnd/lnrpc/rpc.proto.doc.json
@@ -12059,7 +12059,7 @@
           "methods": [
             {
               "name": "WalletBalance",
-              "description": "lncli: `walletbalance`\nWalletBalance returns total unspent outputs(confirmed and unconfirmed), all\nconfirmed unspent outputs and all unconfirmed unspent outputs under control\nof the wallet.",
+              "description": "$pld.category: `Wallet`\n$pld.short_description: `Compute and display the wallet's current balance`\n\nWalletBalance returns total unspent outputs(confirmed and unconfirmed), all\nconfirmed unspent outputs and all unconfirmed unspent outputs under control\nof the wallet.",
               "requestType": "WalletBalanceRequest",
               "requestLongType": "WalletBalanceRequest",
               "requestFullType": "lnrpc.WalletBalanceRequest",
@@ -12071,7 +12071,7 @@
             },
             {
               "name": "GetAddressBalances",
-              "description": "lncli: `getaddressbalances`\nGetAddressBalances returns the balance for each of the addresses in the wallet.",
+              "description": "$pld.category: `Wallet`\n$pld.short_description: ``\nGetAddressBalances returns the balance for each of the addresses in the wallet.",
               "requestType": "GetAddressBalancesRequest",
               "requestLongType": "GetAddressBalancesRequest",
               "requestFullType": "lnrpc.GetAddressBalancesRequest",
@@ -12083,7 +12083,7 @@
             },
             {
               "name": "ChannelBalance",
-              "description": "lncli: `channelbalance`\nChannelBalance returns a report on the total funds across all open channels,\ncategorized in local/remote, pending local/remote and unsettled local/remote\nbalances.",
+              "description": "$pld.category: `Channel`\n$pld.short_description: `Returns the sum of the total available channel balance across all open channels`\n\nChannelBalance returns a report on the total funds across all open channels,\ncategorized in local/remote, pending local/remote and unsettled local/remote\nbalances.",
               "requestType": "ChannelBalanceRequest",
               "requestLongType": "ChannelBalanceRequest",
               "requestFullType": "lnrpc.ChannelBalanceRequest",
@@ -12095,7 +12095,7 @@
             },
             {
               "name": "GetTransactions",
-              "description": "lncli: `listchaintxns`\nGetTransactions returns a list describing all the known transactions\nrelevant to the wallet.",
+              "description": "lncli: `listchaintxns`\n$pld.category: ``\n$pld.short_description: ``\nGetTransactions returns a list describing all the known transactions\nrelevant to the wallet.",
               "requestType": "GetTransactionsRequest",
               "requestLongType": "GetTransactionsRequest",
               "requestFullType": "lnrpc.GetTransactionsRequest",
@@ -12107,7 +12107,7 @@
             },
             {
               "name": "EstimateFee",
-              "description": "lncli: `estimatefee`\nEstimateFee asks the chain backend to estimate the fee rate and total fees\nfor a transaction that pays to multiple specified outputs.\n\nWhen using REST, the `AddrToAmount` map type can be set by appending\n`\u0026AddrToAmount[\u003caddress\u003e]=\u003camount_to_send\u003e` to the URL. Unfortunately this\nmap type doesn't appear in the REST API documentation because of a bug in\nthe grpc-gateway library.",
+              "description": "lncli: `estimatefee`\n$pld.category: ``\n$pld.short_description: ``\nEstimateFee asks the chain backend to estimate the fee rate and total fees\nfor a transaction that pays to multiple specified outputs.\n\nWhen using REST, the `AddrToAmount` map type can be set by appending\n`\u0026AddrToAmount[\u003caddress\u003e]=\u003camount_to_send\u003e` to the URL. Unfortunately this\nmap type doesn't appear in the REST API documentation because of a bug in\nthe grpc-gateway library.",
               "requestType": "EstimateFeeRequest",
               "requestLongType": "EstimateFeeRequest",
               "requestFullType": "lnrpc.EstimateFeeRequest",
@@ -12119,7 +12119,7 @@
             },
             {
               "name": "SendCoins",
-              "description": "lncli: `sendcoins`\nSendCoins executes a request to send coins to a particular address. Unlike\nSendMany, this RPC call only allows creating a single output at a time. If\nneither target_conf, or sat_per_byte are set, then the internal wallet will\nconsult its fee model to determine a fee for the default confirmation\ntarget.",
+              "description": "lncli: `sendcoins`\n$pld.category: ``\n$pld.short_description: ``\nSendCoins executes a request to send coins to a particular address. Unlike\nSendMany, this RPC call only allows creating a single output at a time. If\nneither target_conf, or sat_per_byte are set, then the internal wallet will\nconsult its fee model to determine a fee for the default confirmation\ntarget.",
               "requestType": "SendCoinsRequest",
               "requestLongType": "SendCoinsRequest",
               "requestFullType": "lnrpc.SendCoinsRequest",
@@ -12131,7 +12131,7 @@
             },
             {
               "name": "ListUnspent",
-              "description": "lncli: `listunspent`\nDeprecated, use walletrpc.ListUnspent instead.\n\nListUnspent returns a list of all utxos spendable by the wallet with a\nnumber of confirmations between the specified minimum and maximum.",
+              "description": "lncli: `listunspent`\n$pld.category: ``\n$pld.short_description: ``\nDeprecated, use walletrpc.ListUnspent instead.\n\nListUnspent returns a list of all utxos spendable by the wallet with a\nnumber of confirmations between the specified minimum and maximum.",
               "requestType": "ListUnspentRequest",
               "requestLongType": "ListUnspentRequest",
               "requestFullType": "lnrpc.ListUnspentRequest",
@@ -12143,7 +12143,7 @@
             },
             {
               "name": "SubscribeTransactions",
-              "description": "SubscribeTransactions creates a uni-directional stream from the server to\nthe client in which any newly discovered transactions relevant to the\nwallet are sent over.",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nSubscribeTransactions creates a uni-directional stream from the server to\nthe client in which any newly discovered transactions relevant to the\nwallet are sent over.",
               "requestType": "GetTransactionsRequest",
               "requestLongType": "GetTransactionsRequest",
               "requestFullType": "lnrpc.GetTransactionsRequest",
@@ -12155,7 +12155,7 @@
             },
             {
               "name": "SendMany",
-              "description": "lncli: `sendmany`\nSendMany handles a request for a transaction that creates multiple specified\noutputs in parallel. If neither target_conf, or sat_per_byte are set, then\nthe internal wallet will consult its fee model to determine a fee for the\ndefault confirmation target.",
+              "description": "lncli: `sendmany`\n$pld.category: ``\n$pld.short_description: ``\nSendMany handles a request for a transaction that creates multiple specified\noutputs in parallel. If neither target_conf, or sat_per_byte are set, then\nthe internal wallet will consult its fee model to determine a fee for the\ndefault confirmation target.",
               "requestType": "SendManyRequest",
               "requestLongType": "SendManyRequest",
               "requestFullType": "lnrpc.SendManyRequest",
@@ -12167,7 +12167,7 @@
             },
             {
               "name": "NewAddress",
-              "description": "lncli: `newaddress`\nNewAddress creates a new address under control of the local wallet.",
+              "description": "lncli: `newaddress`\n$pld.category: ``\n$pld.short_description: ``\nNewAddress creates a new address under control of the local wallet.",
               "requestType": "NewAddressRequest",
               "requestLongType": "NewAddressRequest",
               "requestFullType": "lnrpc.NewAddressRequest",
@@ -12179,7 +12179,7 @@
             },
             {
               "name": "SignMessage",
-              "description": "lncli: `signmessage`\nSignMessage signs a message with this node's private key. The returned\nsignature string is `zbase32` encoded and pubkey recoverable, meaning that\nonly the message digest and signature are needed for verification.",
+              "description": "lncli: `signmessage`\n$pld.category: ``\n$pld.short_description: ``\nSignMessage signs a message with this node's private key. The returned\nsignature string is `zbase32` encoded and pubkey recoverable, meaning that\nonly the message digest and signature are needed for verification.",
               "requestType": "SignMessageRequest",
               "requestLongType": "SignMessageRequest",
               "requestFullType": "lnrpc.SignMessageRequest",
@@ -12191,7 +12191,7 @@
             },
             {
               "name": "ConnectPeer",
-              "description": "lncli: `connect`\nConnectPeer attempts to establish a connection to a remote peer. This is at\nthe networking level, and is used for communication between nodes. This is\ndistinct from establishing a channel with a peer.",
+              "description": "lncli: `connect`\n$pld.category: ``\n$pld.short_description: ``\nConnectPeer attempts to establish a connection to a remote peer. This is at\nthe networking level, and is used for communication between nodes. This is\ndistinct from establishing a channel with a peer.",
               "requestType": "ConnectPeerRequest",
               "requestLongType": "ConnectPeerRequest",
               "requestFullType": "lnrpc.ConnectPeerRequest",
@@ -12203,7 +12203,7 @@
             },
             {
               "name": "DisconnectPeer",
-              "description": "lncli: `disconnect`\nDisconnectPeer attempts to disconnect one peer from another identified by a\ngiven pubKey. In the case that we currently have a pending or active channel\nwith the target peer, then this action will be not be allowed.",
+              "description": "lncli: `disconnect`\n$pld.category: ``\n$pld.short_description: ``\nDisconnectPeer attempts to disconnect one peer from another identified by a\ngiven pubKey. In the case that we currently have a pending or active channel\nwith the target peer, then this action will be not be allowed.",
               "requestType": "DisconnectPeerRequest",
               "requestLongType": "DisconnectPeerRequest",
               "requestFullType": "lnrpc.DisconnectPeerRequest",
@@ -12215,7 +12215,7 @@
             },
             {
               "name": "ListPeers",
-              "description": "lncli: `listpeers`\nListPeers returns a verbose listing of all currently active peers.",
+              "description": "lncli: `listpeers`\n$pld.category: ``\n$pld.short_description: ``\nListPeers returns a verbose listing of all currently active peers.",
               "requestType": "ListPeersRequest",
               "requestLongType": "ListPeersRequest",
               "requestFullType": "lnrpc.ListPeersRequest",
@@ -12227,7 +12227,7 @@
             },
             {
               "name": "SubscribePeerEvents",
-              "description": "SubscribePeerEvents creates a uni-directional stream from the server to\nthe client in which any events relevant to the state of peers are sent\nover. Events include peers going online and offline.",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nSubscribePeerEvents creates a uni-directional stream from the server to\nthe client in which any events relevant to the state of peers are sent\nover. Events include peers going online and offline.",
               "requestType": "PeerEventSubscription",
               "requestLongType": "PeerEventSubscription",
               "requestFullType": "lnrpc.PeerEventSubscription",
@@ -12239,7 +12239,7 @@
             },
             {
               "name": "GetInfo",
-              "description": "lncli: `getinfo`\nGetInfo returns general information concerning the lightning node including\nit's identity pubkey, alias, the chains it is connected to, and information\nconcerning the number of open+pending channels.",
+              "description": "lncli: `getinfo`\n$pld.category: ``\n$pld.short_description: ``\nGetInfo returns general information concerning the lightning node including\nit's identity pubkey, alias, the chains it is connected to, and information\nconcerning the number of open+pending channels.",
               "requestType": "GetInfoRequest",
               "requestLongType": "GetInfoRequest",
               "requestFullType": "lnrpc.GetInfoRequest",
@@ -12251,7 +12251,7 @@
             },
             {
               "name": "GetRecoveryInfo",
-              "description": "lncli: `getrecoveryinfo`\nGetRecoveryInfo returns information concerning the recovery mode including\nwhether it's in a recovery mode, whether the recovery is finished, and the\nprogress made so far.",
+              "description": "lncli: `getrecoveryinfo`\n$pld.category: ``\n$pld.short_description: ``\nGetRecoveryInfo returns information concerning the recovery mode including\nwhether it's in a recovery mode, whether the recovery is finished, and the\nprogress made so far.",
               "requestType": "GetRecoveryInfoRequest",
               "requestLongType": "GetRecoveryInfoRequest",
               "requestFullType": "lnrpc.GetRecoveryInfoRequest",
@@ -12263,7 +12263,7 @@
             },
             {
               "name": "PendingChannels",
-              "description": "lncli: `pendingchannels`\nPendingChannels returns a list of all the channels that are currently\nconsidered \"pending\". A channel is pending if it has finished the funding\nworkflow and is waiting for confirmations for the funding txn, or is in the\nprocess of closure, either initiated cooperatively or non-cooperatively.",
+              "description": "$pld.category: `Channel`\n$pld.short_description: `Display information pertaining to pending channels`\n\nPendingChannels returns a list of all the channels that are currently\nconsidered \"pending\". A channel is pending if it has finished the funding\nworkflow and is waiting for confirmations for the funding txn, or is in the\nprocess of closure, either initiated cooperatively or non-cooperatively.",
               "requestType": "PendingChannelsRequest",
               "requestLongType": "PendingChannelsRequest",
               "requestFullType": "lnrpc.PendingChannelsRequest",
@@ -12275,7 +12275,7 @@
             },
             {
               "name": "ListChannels",
-              "description": "lncli: `listchannels`\nListChannels returns a description of all the open channels that this node\nis a participant in.",
+              "description": "$pld.category: `Channel`\n$pld.short_description: `List all open channels`\n\nListChannels returns a description of all the open channels that this node\nis a participant in.",
               "requestType": "ListChannelsRequest",
               "requestLongType": "ListChannelsRequest",
               "requestFullType": "lnrpc.ListChannelsRequest",
@@ -12299,7 +12299,7 @@
             },
             {
               "name": "ClosedChannels",
-              "description": "lncli: `closedchannels`\nClosedChannels returns a description of all the closed channels that\nthis node was a participant in.",
+              "description": "$pld.category: `Channel`\n$pld.short_description: `List all closed channels`\n\nClosedChannels returns a description of all the closed channels that\nthis node was a participant in.",
               "requestType": "ClosedChannelsRequest",
               "requestLongType": "ClosedChannelsRequest",
               "requestFullType": "lnrpc.ClosedChannelsRequest",
@@ -12323,7 +12323,7 @@
             },
             {
               "name": "OpenChannel",
-              "description": "lncli: `openchannel`\nOpenChannel attempts to open a singly funded channel specified in the\nrequest to a remote peer. Users are able to specify a target number of\nblocks that the funding transaction should be confirmed in, or a manual fee\nrate to us for the funding transaction. If neither are specified, then a\nlax block confirmation target is used. Each OpenStatusUpdate will return\nthe pending channel ID of the in-progress channel. Depending on the\narguments specified in the OpenChannelRequest, this pending channel ID can\nthen be used to manually progress the channel funding flow.",
+              "description": "$pld.category: `Channel`\n$pld.short_description: `Open a channel to a node or an existing peer`\n\nOpenChannel attempts to open a singly funded channel specified in the\nrequest to a remote peer. Users are able to specify a target number of\nblocks that the funding transaction should be confirmed in, or a manual fee\nrate to us for the funding transaction. If neither are specified, then a\nlax block confirmation target is used. Each OpenStatusUpdate will return\nthe pending channel ID of the in-progress channel. Depending on the\narguments specified in the OpenChannelRequest, this pending channel ID can\nthen be used to manually progress the channel funding flow.",
               "requestType": "OpenChannelRequest",
               "requestLongType": "OpenChannelRequest",
               "requestFullType": "lnrpc.OpenChannelRequest",
@@ -12335,7 +12335,7 @@
             },
             {
               "name": "FundingStateStep",
-              "description": "FundingStateStep is an advanced funding related call that allows the caller\nto either execute some preparatory steps for a funding workflow, or\nmanually progress a funding workflow. The primary way a funding flow is\nidentified is via its pending channel ID. As an example, this method can be\nused to specify that we're expecting a funding flow for a particular\npending channel ID, for which we need to use specific parameters.\nAlternatively, this can be used to interactively drive PSBT signing for\nfunding for partially complete funding transactions.",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nFundingStateStep is an advanced funding related call that allows the caller\nto either execute some preparatory steps for a funding workflow, or\nmanually progress a funding workflow. The primary way a funding flow is\nidentified is via its pending channel ID. As an example, this method can be\nused to specify that we're expecting a funding flow for a particular\npending channel ID, for which we need to use specific parameters.\nAlternatively, this can be used to interactively drive PSBT signing for\nfunding for partially complete funding transactions.",
               "requestType": "FundingTransitionMsg",
               "requestLongType": "FundingTransitionMsg",
               "requestFullType": "lnrpc.FundingTransitionMsg",
@@ -12347,7 +12347,7 @@
             },
             {
               "name": "ChannelAcceptor",
-              "description": "ChannelAcceptor dispatches a bi-directional streaming RPC in which\nOpenChannel requests are sent to the client and the client responds with\na boolean that tells LND whether or not to accept the channel. This allows\nnode operators to specify their own criteria for accepting inbound channels\nthrough a single persistent connection.",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nChannelAcceptor dispatches a bi-directional streaming RPC in which\nOpenChannel requests are sent to the client and the client responds with\na boolean that tells LND whether or not to accept the channel. This allows\nnode operators to specify their own criteria for accepting inbound channels\nthrough a single persistent connection.",
               "requestType": "ChannelAcceptResponse",
               "requestLongType": "ChannelAcceptResponse",
               "requestFullType": "lnrpc.ChannelAcceptResponse",
@@ -12359,7 +12359,7 @@
             },
             {
               "name": "CloseChannel",
-              "description": "lncli: `closechannel`\nCloseChannel attempts to close an active channel identified by its channel\noutpoint (ChannelPoint). The actions of this method can additionally be\naugmented to attempt a force close after a timeout period in the case of an\ninactive peer. If a non-force close (cooperative closure) is requested,\nthen the user can specify either a target number of blocks until the\nclosure transaction is confirmed, or a manual fee rate. If neither are\nspecified, then a default lax, block confirmation target is used.",
+              "description": "$pld.category: `Channel`\n$pld.short_description: `Close an existing channel`\n\nCloseChannel attempts to close an active channel identified by its channel\noutpoint (ChannelPoint). The actions of this method can additionally be\naugmented to attempt a force close after a timeout period in the case of an\ninactive peer. If a non-force close (cooperative closure) is requested,\nthen the user can specify either a target number of blocks until the\nclosure transaction is confirmed, or a manual fee rate. If neither are\nspecified, then a default lax, block confirmation target is used.",
               "requestType": "CloseChannelRequest",
               "requestLongType": "CloseChannelRequest",
               "requestFullType": "lnrpc.CloseChannelRequest",
@@ -12371,7 +12371,7 @@
             },
             {
               "name": "AbandonChannel",
-              "description": "lncli: `abandonchannel`\nAbandonChannel removes all channel state from the database except for a\nclose summary. This method can be used to get rid of permanently unusable\nchannels due to bugs fixed in newer versions of lnd. This method can also be\nused to remove externally funded channels where the funding transaction was\nnever broadcast. Only available for non-externally funded channels in dev\nbuild.",
+              "description": "$pld.category: `Channel`\n$pld.short_description: `Abandons an existing channel`\n\nAbandonChannel removes all channel state from the database except for a\nclose summary. This method can be used to get rid of permanently unusable\nchannels due to bugs fixed in newer versions of lnd. This method can also be\nused to remove externally funded channels where the funding transaction was\nnever broadcast. Only available for non-externally funded channels in dev\nbuild.",
               "requestType": "AbandonChannelRequest",
               "requestLongType": "AbandonChannelRequest",
               "requestFullType": "lnrpc.AbandonChannelRequest",
@@ -12383,7 +12383,7 @@
             },
             {
               "name": "SendPayment",
-              "description": "lncli: `sendpayment`\nDeprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a\nbi-directional streaming RPC for sending payments through the Lightning\nNetwork. A single RPC invocation creates a persistent bi-directional\nstream allowing clients to rapidly send payments through the Lightning\nNetwork with a single persistent connection.",
+              "description": "Deprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a\nbi-directional streaming RPC for sending payments through the Lightning\nNetwork. A single RPC invocation creates a persistent bi-directional\nstream allowing clients to rapidly send payments through the Lightning\nNetwork with a single persistent connection.",
               "requestType": "SendRequest",
               "requestLongType": "SendRequest",
               "requestFullType": "lnrpc.SendRequest",
@@ -12437,7 +12437,7 @@
             },
             {
               "name": "AddInvoice",
-              "description": "lncli: `addinvoice`\nAddInvoice attempts to add a new invoice to the invoice database. Any\nduplicated invoices are rejected, therefore all invoices *must* have a\nunique payment preimage.",
+              "description": "$pld.category: `Invoice`\n$pld.short_description: `Add a new invoice`\n\nAddInvoice attempts to add a new invoice to the invoice database. Any\nduplicated invoices are rejected, therefore all invoices *must* have a\nunique payment preimage.",
               "requestType": "Invoice",
               "requestLongType": "Invoice",
               "requestFullType": "lnrpc.Invoice",
@@ -12449,7 +12449,7 @@
             },
             {
               "name": "ListInvoices",
-              "description": "lncli: `listinvoices`\nListInvoices returns a list of all the invoices currently stored within the\ndatabase. Any active debug invoices are ignored. It has full support for\npaginated responses, allowing users to query for specific invoices through\ntheir add_index. This can be done by using either the first_index_offset or\nlast_index_offset fields included in the response as the index_offset of the\nnext request. By default, the first 100 invoices created will be returned.\nBackwards pagination is also supported through the Reversed flag.",
+              "description": "$pld.category: `Invoice`\n$pld.short_description: `List all invoices currently stored within the database. Any active debug invoices are ignored`\n\nListInvoices returns a list of all the invoices currently stored within the\ndatabase. Any active debug invoices are ignored. It has full support for\npaginated responses, allowing users to query for specific invoices through\ntheir add_index. This can be done by using either the first_index_offset or\nlast_index_offset fields included in the response as the index_offset of the\nnext request. By default, the first 100 invoices created will be returned.\nBackwards pagination is also supported through the Reversed flag.",
               "requestType": "ListInvoiceRequest",
               "requestLongType": "ListInvoiceRequest",
               "requestFullType": "lnrpc.ListInvoiceRequest",
@@ -12461,7 +12461,7 @@
             },
             {
               "name": "LookupInvoice",
-              "description": "lncli: `lookupinvoice`\nLookupInvoice attempts to look up an invoice according to its payment hash.\nThe passed payment hash *must* be exactly 32 bytes, if not, an error is\nreturned.",
+              "description": "$pld.category: `Invoice`\n$pld.short_description: `Lookup an existing invoice by its payment hash`\n\nLookupInvoice attempts to look up an invoice according to its payment hash.\nThe passed payment hash *must* be exactly 32 bytes, if not, an error is\nreturned.",
               "requestType": "PaymentHash",
               "requestLongType": "PaymentHash",
               "requestFullType": "lnrpc.PaymentHash",
@@ -12473,7 +12473,7 @@
             },
             {
               "name": "SubscribeInvoices",
-              "description": "SubscribeInvoices returns a uni-directional stream (server -\u003e client) for\nnotifying the client of newly added/settled invoices. The caller can\noptionally specify the add_index and/or the settle_index. If the add_index\nis specified, then we'll first start by sending add invoice events for all\ninvoices with an add_index greater than the specified value. If the\nsettle_index is specified, the next, we'll send out all settle events for\ninvoices with a settle_index greater than the specified value. One or both\nof these fields can be set. If no fields are set, then we'll only send out\nthe latest add/settle events.",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nSubscribeInvoices returns a uni-directional stream (server -\u003e client) for\nnotifying the client of newly added/settled invoices. The caller can\noptionally specify the add_index and/or the settle_index. If the add_index\nis specified, then we'll first start by sending add invoice events for all\ninvoices with an add_index greater than the specified value. If the\nsettle_index is specified, the next, we'll send out all settle events for\ninvoices with a settle_index greater than the specified value. One or both\nof these fields can be set. If no fields are set, then we'll only send out\nthe latest add/settle events.",
               "requestType": "InvoiceSubscription",
               "requestLongType": "InvoiceSubscription",
               "requestFullType": "lnrpc.InvoiceSubscription",
@@ -12485,7 +12485,7 @@
             },
             {
               "name": "DecodePayReq",
-              "description": "lncli: `decodepayreq`\nDecodePayReq takes an encoded payment request string and attempts to decode\nit, returning a full description of the conditions encoded within the\npayment request.",
+              "description": "$pld.category: `Invoice`\n$pld.short_description: `Decode a payment request`\n\nDecodePayReq takes an encoded payment request string and attempts to decode\nit, returning a full description of the conditions encoded within the\npayment request.",
               "requestType": "PayReqString",
               "requestLongType": "PayReqString",
               "requestFullType": "lnrpc.PayReqString",
@@ -12497,7 +12497,7 @@
             },
             {
               "name": "ListPayments",
-              "description": "lncli: `listpayments`\nListPayments returns a list of all outgoing payments.",
+              "description": "$pld.category: `Payment`\n$pld.short_description: `List all outgoing payments`\n\nListPayments returns a list of all outgoing payments.",
               "requestType": "ListPaymentsRequest",
               "requestLongType": "ListPaymentsRequest",
               "requestFullType": "lnrpc.ListPaymentsRequest",
@@ -12521,7 +12521,7 @@
             },
             {
               "name": "DescribeGraph",
-              "description": "lncli: `describegraph`\nDescribeGraph returns a description of the latest graph state from the\npoint of view of the node. The graph information is partitioned into two\ncomponents: all the nodes/vertexes, and all the edges that connect the\nvertexes themselves. As this is a directed graph, the edges also contain\nthe node directional specific routing policy which includes: the time lock\ndelta, fee information, etc.",
+              "description": "$pld.category: `Graph`\n$pld.short_description: `Describe the network graph`\n\nDescribeGraph returns a description of the latest graph state from the\npoint of view of the node. The graph information is partitioned into two\ncomponents: all the nodes/vertexes, and all the edges that connect the\nvertexes themselves. As this is a directed graph, the edges also contain\nthe node directional specific routing policy which includes: the time lock\ndelta, fee information, etc.",
               "requestType": "ChannelGraphRequest",
               "requestLongType": "ChannelGraphRequest",
               "requestFullType": "lnrpc.ChannelGraphRequest",
@@ -12533,7 +12533,7 @@
             },
             {
               "name": "GetNodeMetrics",
-              "description": "lncli: `getnodemetrics`\nGetNodeMetrics returns node metrics calculated from the graph. Currently\nthe only supported metric is betweenness centrality of individual nodes.",
+              "description": "$pld.category: `Graph`\n$pld.short_description: `Get node metrics`\n\nGetNodeMetrics returns node metrics calculated from the graph. Currently\nthe only supported metric is betweenness centrality of individual nodes.",
               "requestType": "NodeMetricsRequest",
               "requestLongType": "NodeMetricsRequest",
               "requestFullType": "lnrpc.NodeMetricsRequest",
@@ -12545,7 +12545,7 @@
             },
             {
               "name": "GetChanInfo",
-              "description": "lncli: `getchaninfo`\nGetChanInfo returns the latest authenticated network announcement for the\ngiven channel identified by its channel ID: an 8-byte integer which\nuniquely identifies the location of transaction's funding output within the\nblockchain.",
+              "description": "$pld.category: `Graph`\n$pld.short_description: `Get the state of a channel`\n\nGetChanInfo returns the latest authenticated network announcement for the\ngiven channel identified by its channel ID: an 8-byte integer which\nuniquely identifies the location of transaction's funding output within the\nblockchain.",
               "requestType": "ChanInfoRequest",
               "requestLongType": "ChanInfoRequest",
               "requestFullType": "lnrpc.ChanInfoRequest",
@@ -12557,7 +12557,7 @@
             },
             {
               "name": "GetNodeInfo",
-              "description": "lncli: `getnodeinfo`\nGetNodeInfo returns the latest advertised, aggregated, and authenticated\nchannel information for the specified node identified by its public key.",
+              "description": "$pld.category: `Graph`\n$pld.short_description: `Get information on a specific node`\n\nGetNodeInfo returns the latest advertised, aggregated, and authenticated\nchannel information for the specified node identified by its public key.",
               "requestType": "NodeInfoRequest",
               "requestLongType": "NodeInfoRequest",
               "requestFullType": "lnrpc.NodeInfoRequest",
@@ -12569,7 +12569,7 @@
             },
             {
               "name": "QueryRoutes",
-              "description": "lncli: `queryroutes`\nQueryRoutes attempts to query the daemon's Channel Router for a possible\nroute to a target destination capable of carrying a specific amount of\nsatoshis. The returned route contains the full details required to craft and\nsend an HTLC, also including the necessary information that should be\npresent within the Sphinx packet encapsulated within the HTLC.\n\nWhen using REST, the `dest_custom_records` map type can be set by appending\n`\u0026dest_custom_records[\u003crecord_number\u003e]=\u003crecord_data_base64_url_encoded\u003e`\nto the URL. Unfortunately this map type doesn't appear in the REST API\ndocumentation because of a bug in the grpc-gateway library.",
+              "description": "$pld.category: `Payment`\n$pld.short_description: `Query a route to a destination`\n\nQueryRoutes attempts to query the daemon's Channel Router for a possible\nroute to a target destination capable of carrying a specific amount of\nsatoshis. The returned route contains the full details required to craft and\nsend an HTLC, also including the necessary information that should be\npresent within the Sphinx packet encapsulated within the HTLC.\n\nWhen using REST, the `dest_custom_records` map type can be set by appending\n`\u0026dest_custom_records[\u003crecord_number\u003e]=\u003crecord_data_base64_url_encoded\u003e`\nto the URL. Unfortunately this map type doesn't appear in the REST API\ndocumentation because of a bug in the grpc-gateway library.",
               "requestType": "QueryRoutesRequest",
               "requestLongType": "QueryRoutesRequest",
               "requestFullType": "lnrpc.QueryRoutesRequest",
@@ -12581,7 +12581,7 @@
             },
             {
               "name": "GetNetworkInfo",
-              "description": "lncli: `getnetworkinfo`\nGetNetworkInfo returns some basic stats about the known channel graph from\nthe point of view of the node.",
+              "description": "$pld.category: `Channel`\n$pld.short_description: `Get statistical information about the current state of the network`\n\nGetNetworkInfo returns some basic stats about the known channel graph from\nthe point of view of the node.",
               "requestType": "NetworkInfoRequest",
               "requestLongType": "NetworkInfoRequest",
               "requestFullType": "lnrpc.NetworkInfoRequest",
@@ -12593,7 +12593,7 @@
             },
             {
               "name": "StopDaemon",
-              "description": "lncli: `stop`\nStopDaemon will send a shutdown request to the interrupt handler, triggering\na graceful shutdown of the daemon.",
+              "description": "lncli: `stop`\n$pld.category: ``\n$pld.short_description: ``\nStopDaemon will send a shutdown request to the interrupt handler, triggering\na graceful shutdown of the daemon.",
               "requestType": "StopRequest",
               "requestLongType": "StopRequest",
               "requestFullType": "lnrpc.StopRequest",
@@ -12617,7 +12617,7 @@
             },
             {
               "name": "DebugLevel",
-              "description": "lncli: `debuglevel`\nDebugLevel allows a caller to programmatically set the logging verbosity of\nlnd. The logging can be targeted according to a coarse daemon-wide logging\nlevel, or in a granular fashion to specify the logging for a target\nsub-system.",
+              "description": "lncli: `debuglevel`\n$pld.category: ``\n$pld.short_description: ``\nDebugLevel allows a caller to programmatically set the logging verbosity of\nlnd. The logging can be targeted according to a coarse daemon-wide logging\nlevel, or in a granular fashion to specify the logging for a target\nsub-system.",
               "requestType": "DebugLevelRequest",
               "requestLongType": "DebugLevelRequest",
               "requestFullType": "lnrpc.DebugLevelRequest",
@@ -12629,7 +12629,7 @@
             },
             {
               "name": "FeeReport",
-              "description": "lncli: `feereport`\nFeeReport allows the caller to obtain a report detailing the current fee\nschedule enforced by the node globally for each channel.",
+              "description": "$pld.category: `Channel`\n$pld.short_description: `Display the current fee policies of all active channels`\n\nFeeReport allows the caller to obtain a report detailing the current fee\nschedule enforced by the node globally for each channel.",
               "requestType": "FeeReportRequest",
               "requestLongType": "FeeReportRequest",
               "requestFullType": "lnrpc.FeeReportRequest",
@@ -12641,7 +12641,7 @@
             },
             {
               "name": "UpdateChannelPolicy",
-              "description": "lncli: `updatechanpolicy`\nUpdateChannelPolicy allows the caller to update the fee schedule and\nchannel policies for all channels globally, or a particular channel.",
+              "description": "$pld.category: `Channel`\n$pld.short_description: `Update the channel policy for all channels, or a single channel`\n\nUpdateChannelPolicy allows the caller to update the fee schedule and\nchannel policies for all channels globally, or a particular channel.",
               "requestType": "PolicyUpdateRequest",
               "requestLongType": "PolicyUpdateRequest",
               "requestFullType": "lnrpc.PolicyUpdateRequest",
@@ -12653,7 +12653,7 @@
             },
             {
               "name": "ForwardingHistory",
-              "description": "lncli: `fwdinghistory`\nForwardingHistory allows the caller to query the htlcswitch for a record of\nall HTLCs forwarded within the target time range, and integer offset\nwithin that time range. If no time-range is specified, then the first chunk\nof the past 24 hrs of forwarding history are returned.\n\nA list of forwarding events are returned. The size of each forwarding event\nis 40 bytes, and the max message size able to be returned in gRPC is 4 MiB.\nAs a result each message can only contain 50k entries. Each response has\nthe index offset of the last entry. The index offset can be provided to the\nrequest to allow the caller to skip a series of records.",
+              "description": "$pld.category: `Payment`\n$pld.short_description: `Query the history of all forwarded HTLCs`\n\nForwardingHistory allows the caller to query the htlcswitch for a record of\nall HTLCs forwarded within the target time range, and integer offset\nwithin that time range. If no time-range is specified, then the first chunk\nof the past 24 hrs of forwarding history are returned.\n\nA list of forwarding events are returned. The size of each forwarding event\nis 40 bytes, and the max message size able to be returned in gRPC is 4 MiB.\nAs a result each message can only contain 50k entries. Each response has\nthe index offset of the last entry. The index offset can be provided to the\nrequest to allow the caller to skip a series of records.",
               "requestType": "ForwardingHistoryRequest",
               "requestLongType": "ForwardingHistoryRequest",
               "requestFullType": "lnrpc.ForwardingHistoryRequest",
@@ -12665,7 +12665,7 @@
             },
             {
               "name": "ExportChannelBackup",
-              "description": "lncli: `exportchanbackup`\nExportChannelBackup attempts to return an encrypted static channel backup\nfor the target channel identified by it channel point. The backup is\nencrypted with a key generated from the aezeed seed of the user. The\nreturned backup can either be restored using the RestoreChannelBackup\nmethod once lnd is running, or via the InitWallet and UnlockWallet methods\nfrom the WalletUnlocker service.",
+              "description": "$pld.category: `Backup`\n$pld.short_description: `Obtain a static channel back up for a selected channels, or all known channels`\n\nExportChannelBackup attempts to return an encrypted static channel backup\nfor the target channel identified by it channel point. The backup is\nencrypted with a key generated from the aezeed seed of the user. The\nreturned backup can either be restored using the RestoreChannelBackup\nmethod once lnd is running, or via the InitWallet and UnlockWallet methods\nfrom the WalletUnlocker service.",
               "requestType": "ExportChannelBackupRequest",
               "requestLongType": "ExportChannelBackupRequest",
               "requestFullType": "lnrpc.ExportChannelBackupRequest",
@@ -12689,7 +12689,7 @@
             },
             {
               "name": "VerifyChanBackup",
-              "description": "VerifyChanBackup allows a caller to verify the integrity of a channel backup\nsnapshot. This method will accept either a packed Single or a packed Multi.\nSpecifying both will result in an error.",
+              "description": "$pld.category: `Backup`\n$pld.short_description: `Verify an existing channel backup`\n\nVerifyChanBackup allows a caller to verify the integrity of a channel backup\nsnapshot. This method will accept either a packed Single or a packed Multi.\nSpecifying both will result in an error.",
               "requestType": "ChanBackupSnapshot",
               "requestLongType": "ChanBackupSnapshot",
               "requestFullType": "lnrpc.ChanBackupSnapshot",
@@ -12701,7 +12701,7 @@
             },
             {
               "name": "RestoreChannelBackups",
-              "description": "lncli: `restorechanbackup`\nRestoreChannelBackups accepts a set of singular channel backups, or a\nsingle encrypted multi-chan backup and attempts to recover any funds\nremaining within the channel. If we are able to unpack the backup, then the\nnew channel will be shown under listchannels, as well as pending channels.",
+              "description": "$pld.category: `Backup`\n$pld.short_description: `Restore an existing single or multi-channel static channel backup`\n\nRestoreChannelBackups accepts a set of singular channel backups, or a\nsingle encrypted multi-chan backup and attempts to recover any funds\nremaining within the channel. If we are able to unpack the backup, then the\nnew channel will be shown under listchannels, as well as pending channels.",
               "requestType": "RestoreChanBackupRequest",
               "requestLongType": "RestoreChanBackupRequest",
               "requestFullType": "lnrpc.RestoreChanBackupRequest",
@@ -12725,7 +12725,7 @@
             },
             {
               "name": "ReSync",
-              "description": "Scan over the chain to find any transactions which may not have been recorded in the wallet's database",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nScan over the chain to find any transactions which may not have been recorded in the wallet's database",
               "requestType": "ReSyncChainRequest",
               "requestLongType": "ReSyncChainRequest",
               "requestFullType": "lnrpc.ReSyncChainRequest",
@@ -12737,7 +12737,7 @@
             },
             {
               "name": "StopReSync",
-              "description": "Stop a re-synchronization job before it's completion",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nStop a re-synchronization job before it's completion",
               "requestType": "StopReSyncRequest",
               "requestLongType": "StopReSyncRequest",
               "requestFullType": "lnrpc.StopReSyncRequest",
@@ -12749,7 +12749,7 @@
             },
             {
               "name": "GetWalletSeed",
-              "description": "Get the wallet seed words for this wallet",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nGet the wallet seed words for this wallet",
               "requestType": "GetWalletSeedRequest",
               "requestLongType": "GetWalletSeedRequest",
               "requestFullType": "lnrpc.GetWalletSeedRequest",
@@ -12761,7 +12761,7 @@
             },
             {
               "name": "ChangeSeedPassphrase",
-              "description": "Change seed's passphrase",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nChange seed's passphrase",
               "requestType": "ChangeSeedPassphraseRequest",
               "requestLongType": "ChangeSeedPassphraseRequest",
               "requestFullType": "lnrpc.ChangeSeedPassphraseRequest",
@@ -12773,7 +12773,7 @@
             },
             {
               "name": "GetSecret",
-              "description": "Get a secret seed which is generated using the wallet's private key, this can be used as a password for another application",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nGet a secret seed which is generated using the wallet's private key, this can be used as a password for another application",
               "requestType": "GetSecretRequest",
               "requestLongType": "GetSecretRequest",
               "requestFullType": "lnrpc.GetSecretRequest",
@@ -12785,7 +12785,7 @@
             },
             {
               "name": "ImportPrivKey",
-              "description": "Imports a WIF-encoded private key to the 'imported' account.",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nImports a WIF-encoded private key to the 'imported' account.",
               "requestType": "ImportPrivKeyRequest",
               "requestLongType": "ImportPrivKeyRequest",
               "requestFullType": "lnrpc.ImportPrivKeyRequest",
@@ -12797,7 +12797,7 @@
             },
             {
               "name": "DumpPrivKey",
-              "description": "Returns the private key in WIF encoding that controls some wallet address.",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nReturns the private key in WIF encoding that controls some wallet address.",
               "requestType": "DumpPrivKeyRequest",
               "requestLongType": "DumpPrivKeyRequest",
               "requestFullType": "lnrpc.DumpPrivKeyRequest",
@@ -12809,7 +12809,7 @@
             },
             {
               "name": "ListLockUnspent",
-              "description": "Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nReturns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.",
               "requestType": "ListLockUnspentRequest",
               "requestLongType": "ListLockUnspentRequest",
               "requestFullType": "lnrpc.ListLockUnspentRequest",
@@ -12821,7 +12821,7 @@
             },
             {
               "name": "LockUnspent",
-              "description": "Locks or unlocks an unspent output",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nLocks or unlocks an unspent output",
               "requestType": "LockUnspentRequest",
               "requestLongType": "LockUnspentRequest",
               "requestFullType": "lnrpc.LockUnspentRequest",
@@ -12833,7 +12833,7 @@
             },
             {
               "name": "CreateTransaction",
-              "description": "Create a transaction but po not send it to the chain",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nCreate a transaction but po not send it to the chain",
               "requestType": "CreateTransactionRequest",
               "requestLongType": "CreateTransactionRequest",
               "requestFullType": "lnrpc.CreateTransactionRequest",
@@ -12845,7 +12845,7 @@
             },
             {
               "name": "GetNewAddress",
-              "description": "Generates and returns a new payment address",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nGenerates and returns a new payment address",
               "requestType": "GetNewAddressRequest",
               "requestLongType": "GetNewAddressRequest",
               "requestFullType": "lnrpc.GetNewAddressRequest",
@@ -12857,7 +12857,7 @@
             },
             {
               "name": "GetTransaction",
-              "description": "Returns a JSON object with details regarding a transaction relevant to this wallet.",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nReturns a JSON object with details regarding a transaction relevant to this wallet.",
               "requestType": "GetTransactionRequest",
               "requestLongType": "GetTransactionRequest",
               "requestFullType": "lnrpc.GetTransactionRequest",
@@ -12869,7 +12869,7 @@
             },
             {
               "name": "SetNetworkStewardVote",
-              "description": "Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nConfigure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)",
               "requestType": "SetNetworkStewardVoteRequest",
               "requestLongType": "SetNetworkStewardVoteRequest",
               "requestFullType": "lnrpc.SetNetworkStewardVoteRequest",
@@ -12881,7 +12881,7 @@
             },
             {
               "name": "GetNetworkStewardVote",
-              "description": "Find out how the wallet is currently configured to vote in a network steward election",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nFind out how the wallet is currently configured to vote in a network steward election",
               "requestType": "GetNetworkStewardVoteRequest",
               "requestLongType": "GetNetworkStewardVoteRequest",
               "requestFullType": "lnrpc.GetNetworkStewardVoteRequest",
@@ -12893,7 +12893,7 @@
             },
             {
               "name": "BcastTransaction",
-              "description": "Broadcast a transaction",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nBroadcast a transaction",
               "requestType": "BcastTransactionRequest",
               "requestLongType": "BcastTransactionRequest",
               "requestFullType": "lnrpc.BcastTransactionRequest",
@@ -12905,7 +12905,7 @@
             },
             {
               "name": "SendFrom",
-              "description": "SendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.",
+              "description": "$pld.category: ``\n$pld.short_description: ``\nSendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.",
               "requestType": "SendFromRequest",
               "requestLongType": "SendFromRequest",
               "requestFullType": "lnrpc.SendFromRequest",

--- a/lnd/lnrpc/rpc_grpc.pb.go
+++ b/lnd/lnrpc/rpc_grpc.pb.go
@@ -27,8 +27,9 @@ type LightningClient interface {
 	//of the wallet.
 	WalletBalance(ctx context.Context, in *WalletBalanceRequest, opts ...grpc.CallOption) (*WalletBalanceResponse, error)
 	//
-	//$pld.category: `Wallet`
-	//$pld.short_description: ``
+	//$pld.category: `Address`
+	//$pld.short_description: `Compute and display balances for each address in the wallet`
+	//
 	//GetAddressBalances returns the balance for each of the addresses in the wallet.
 	GetAddressBalances(ctx context.Context, in *GetAddressBalancesRequest, opts ...grpc.CallOption) (*GetAddressBalancesResponse, error)
 	//
@@ -39,15 +40,17 @@ type LightningClient interface {
 	//categorized in local/remote, pending local/remote and unsettled local/remote
 	//balances.
 	ChannelBalance(ctx context.Context, in *ChannelBalanceRequest, opts ...grpc.CallOption) (*ChannelBalanceResponse, error)
-	// lncli: `listchaintxns`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Transaction`
+	//$pld.short_description: `List transactions from the wallet`
+	//
 	//GetTransactions returns a list describing all the known transactions
 	//relevant to the wallet.
 	GetTransactions(ctx context.Context, in *GetTransactionsRequest, opts ...grpc.CallOption) (*TransactionDetails, error)
-	// lncli: `estimatefee`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Neutrino`
+	//$pld.short_description: `Get fee estimates for sending bitcoin on-chain to multiple addresses`
+	//
 	//EstimateFee asks the chain backend to estimate the fee rate and total fees
 	//for a transaction that pays to multiple specified outputs.
 	//
@@ -56,9 +59,10 @@ type LightningClient interface {
 	//map type doesn't appear in the REST API documentation because of a bug in
 	//the grpc-gateway library.
 	EstimateFee(ctx context.Context, in *EstimateFeeRequest, opts ...grpc.CallOption) (*EstimateFeeResponse, error)
-	// lncli: `sendcoins`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Transaction`
+	//$pld.short_description: `Send bitcoin on-chain to an address`
+	//
 	//SendCoins executes a request to send coins to a particular address. Unlike
 	//SendMany, this RPC call only allows creating a single output at a time. If
 	//neither target_conf, or sat_per_byte are set, then the internal wallet will
@@ -66,76 +70,69 @@ type LightningClient interface {
 	//target.
 	SendCoins(ctx context.Context, in *SendCoinsRequest, opts ...grpc.CallOption) (*SendCoinsResponse, error)
 	// lncli: `listunspent`
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//Deprecated, use walletrpc.ListUnspent instead.
 	//
 	//ListUnspent returns a list of all utxos spendable by the wallet with a
 	//number of confirmations between the specified minimum and maximum.
 	ListUnspent(ctx context.Context, in *ListUnspentRequest, opts ...grpc.CallOption) (*ListUnspentResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//SubscribeTransactions creates a uni-directional stream from the server to
 	//the client in which any newly discovered transactions relevant to the
 	//wallet are sent over.
 	SubscribeTransactions(ctx context.Context, in *GetTransactionsRequest, opts ...grpc.CallOption) (Lightning_SubscribeTransactionsClient, error)
-	// lncli: `sendmany`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Transaction`
+	//$pld.short_description: `Send bitcoin on-chain to multiple addresses`
+	//
 	//SendMany handles a request for a transaction that creates multiple specified
 	//outputs in parallel. If neither target_conf, or sat_per_byte are set, then
 	//the internal wallet will consult its fee model to determine a fee for the
 	//default confirmation target.
 	SendMany(ctx context.Context, in *SendManyRequest, opts ...grpc.CallOption) (*SendManyResponse, error)
-	// lncli: `newaddress`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
 	//NewAddress creates a new address under control of the local wallet.
 	NewAddress(ctx context.Context, in *NewAddressRequest, opts ...grpc.CallOption) (*NewAddressResponse, error)
-	// lncli: `signmessage`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Address`
+	//$pld.short_description: `Signs a message using the private key of a payment address`
+	//
 	//SignMessage signs a message with this node's private key. The returned
 	//signature string is `zbase32` encoded and pubkey recoverable, meaning that
 	//only the message digest and signature are needed for verification.
 	SignMessage(ctx context.Context, in *SignMessageRequest, opts ...grpc.CallOption) (*SignMessageResponse, error)
-	// lncli: `connect`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Peer`
+	//$pld.short_description: `Connect to a remote pld peer`
+	//
 	//ConnectPeer attempts to establish a connection to a remote peer. This is at
 	//the networking level, and is used for communication between nodes. This is
 	//distinct from establishing a channel with a peer.
 	ConnectPeer(ctx context.Context, in *ConnectPeerRequest, opts ...grpc.CallOption) (*ConnectPeerResponse, error)
-	// lncli: `disconnect`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Peer`
+	//$pld.short_description: `Disconnect a remote pld peer identified by public key`
+	//
 	//DisconnectPeer attempts to disconnect one peer from another identified by a
 	//given pubKey. In the case that we currently have a pending or active channel
 	//with the target peer, then this action will be not be allowed.
 	DisconnectPeer(ctx context.Context, in *DisconnectPeerRequest, opts ...grpc.CallOption) (*DisconnectPeerResponse, error)
-	// lncli: `listpeers`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Peer`
+	//$pld.short_description: `List all active, currently connected peers`
+	//
 	//ListPeers returns a verbose listing of all currently active peers.
 	ListPeers(ctx context.Context, in *ListPeersRequest, opts ...grpc.CallOption) (*ListPeersResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//SubscribePeerEvents creates a uni-directional stream from the server to
 	//the client in which any events relevant to the state of peers are sent
 	//over. Events include peers going online and offline.
 	SubscribePeerEvents(ctx context.Context, in *PeerEventSubscription, opts ...grpc.CallOption) (Lightning_SubscribePeerEventsClient, error)
-	// lncli: `getinfo`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
 	//GetInfo returns general information concerning the lightning node including
 	//it's identity pubkey, alias, the chains it is connected to, and information
 	//concerning the number of open+pending channels.
 	GetInfo(ctx context.Context, in *GetInfoRequest, opts ...grpc.CallOption) (*GetInfoResponse, error)
 	//* lncli: `getrecoveryinfo`
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//GetRecoveryInfo returns information concerning the recovery mode including
 	//whether it's in a recovery mode, whether the recovery is finished, and the
 	//progress made so far.
@@ -189,8 +186,6 @@ type LightningClient interface {
 	//then be used to manually progress the channel funding flow.
 	OpenChannel(ctx context.Context, in *OpenChannelRequest, opts ...grpc.CallOption) (Lightning_OpenChannelClient, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//FundingStateStep is an advanced funding related call that allows the caller
 	//to either execute some preparatory steps for a funding workflow, or
 	//manually progress a funding workflow. The primary way a funding flow is
@@ -201,8 +196,6 @@ type LightningClient interface {
 	//funding for partially complete funding transactions.
 	FundingStateStep(ctx context.Context, in *FundingTransitionMsg, opts ...grpc.CallOption) (*FundingStateStepResp, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//ChannelAcceptor dispatches a bi-directional streaming RPC in which
 	//OpenChannel requests are sent to the client and the client responds with
 	//a boolean that tells LND whether or not to accept the channel. This allows
@@ -287,8 +280,6 @@ type LightningClient interface {
 	//returned.
 	LookupInvoice(ctx context.Context, in *PaymentHash, opts ...grpc.CallOption) (*Invoice, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//SubscribeInvoices returns a uni-directional stream (server -> client) for
 	//notifying the client of newly added/settled invoices. The caller can
 	//optionally specify the add_index and/or the settle_index. If the add_index
@@ -372,9 +363,10 @@ type LightningClient interface {
 	//GetNetworkInfo returns some basic stats about the known channel graph from
 	//the point of view of the node.
 	GetNetworkInfo(ctx context.Context, in *NetworkInfoRequest, opts ...grpc.CallOption) (*NetworkInfo, error)
-	// lncli: `stop`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Meta`
+	//$pld.short_description: `Stop and shutdown the daemon`
+	//
 	//StopDaemon will send a shutdown request to the interrupt handler, triggering
 	//a graceful shutdown of the daemon.
 	StopDaemon(ctx context.Context, in *StopRequest, opts ...grpc.CallOption) (*StopResponse, error)
@@ -386,9 +378,10 @@ type LightningClient interface {
 	//channels being advertised, updates in the routing policy for a directional
 	//channel edge, and when channels are closed on-chain.
 	SubscribeChannelGraph(ctx context.Context, in *GraphTopologySubscription, opts ...grpc.CallOption) (Lightning_SubscribeChannelGraphClient, error)
-	// lncli: `debuglevel`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Meta`
+	//$pld.short_description: `Set the debug level`
+	//
 	//DebugLevel allows a caller to programmatically set the logging verbosity of
 	//lnd. The logging can be targeted according to a coarse daemon-wide logging
 	//level, or in a granular fashion to specify the logging for a target
@@ -468,84 +461,100 @@ type LightningClient interface {
 	//channel(s) removed.
 	SubscribeChannelBackups(ctx context.Context, in *ChannelBackupSubscription, opts ...grpc.CallOption) (Lightning_SubscribeChannelBackupsClient, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Unspent`
+	//$pld.short_description: `Scan over the chain to find any transactions which may not have been recorded in the wallet's database`
+	//
 	//Scan over the chain to find any transactions which may not have been recorded in the wallet's database
 	ReSync(ctx context.Context, in *ReSyncChainRequest, opts ...grpc.CallOption) (*ReSyncChainResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Unspent`
+	//$pld.short_description: `Stop a re-synchronization job before it's completion`
+	//
 	//Stop a re-synchronization job before it's completion
 	StopReSync(ctx context.Context, in *StopReSyncRequest, opts ...grpc.CallOption) (*StopReSyncResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Get the wallet seed words for this wallet`
+	//
 	//Get the wallet seed words for this wallet
 	GetWalletSeed(ctx context.Context, in *GetWalletSeedRequest, opts ...grpc.CallOption) (*GetWalletSeedResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Seed`
+	//$pld.short_description: `Alter the passphrase which is used to encrypt a wallet seed`
+	//
 	//Change seed's passphrase
 	ChangeSeedPassphrase(ctx context.Context, in *ChangeSeedPassphraseRequest, opts ...grpc.CallOption) (*ChangeSeedPassphraseResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Get a secret seed`
+	//
 	//Get a secret seed which is generated using the wallet's private key, this can be used as a password for another application
 	GetSecret(ctx context.Context, in *GetSecretRequest, opts ...grpc.CallOption) (*GetSecretResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Address`
+	//$pld.short_description: `Imports a WIF-encoded private key to the 'imported' account`
+	//
 	//Imports a WIF-encoded private key to the 'imported' account.
 	ImportPrivKey(ctx context.Context, in *ImportPrivKeyRequest, opts ...grpc.CallOption) (*ImportPrivKeyResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Address`
+	//$pld.short_description: `Returns the private key in WIF encoding that controls some wallet address`
+	//
 	//Returns the private key in WIF encoding that controls some wallet address.
 	DumpPrivKey(ctx context.Context, in *DumpPrivKeyRequest, opts ...grpc.CallOption) (*DumpPrivKeyResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Lock`
+	//$pld.short_description: `Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session`
+	//
 	//Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.
 	ListLockUnspent(ctx context.Context, in *ListLockUnspentRequest, opts ...grpc.CallOption) (*ListLockUnspentResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Lock`
+	//$pld.short_description: `Locks or unlocks an unspent output`
+	//
 	//Locks or unlocks an unspent output
 	LockUnspent(ctx context.Context, in *LockUnspentRequest, opts ...grpc.CallOption) (*LockUnspentResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Transaction`
+	//$pld.short_description: `Create a transaction but do not send it to the chain`
+	//
 	//Create a transaction but po not send it to the chain
 	CreateTransaction(ctx context.Context, in *CreateTransactionRequest, opts ...grpc.CallOption) (*CreateTransactionResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Address`
+	//$pld.short_description: `Generates a new address`
+	//
 	//Generates and returns a new payment address
 	GetNewAddress(ctx context.Context, in *GetNewAddressRequest, opts ...grpc.CallOption) (*GetNewAddressResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Transaction`
+	//$pld.short_description: `Returns a JSON object with details regarding a transaction relevant to this wallet`
+	//
 	//Returns a JSON object with details regarding a transaction relevant to this wallet.
 	GetTransaction(ctx context.Context, in *GetTransactionRequest, opts ...grpc.CallOption) (*GetTransactionResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Network Steward Vote`
+	//$pld.short_description: `Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)`
+	//
 	//Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)
 	SetNetworkStewardVote(ctx context.Context, in *SetNetworkStewardVoteRequest, opts ...grpc.CallOption) (*SetNetworkStewardVoteResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Network Steward Vote`
+	//$pld.short_description: `Find out how the wallet is currently configured to vote in a network steward election`
+	//
 	//Find out how the wallet is currently configured to vote in a network steward election
 	GetNetworkStewardVote(ctx context.Context, in *GetNetworkStewardVoteRequest, opts ...grpc.CallOption) (*GetNetworkStewardVoteResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Neutrino`
+	//$pld.short_description: `Broadcast a transaction onchain`
+	//
 	//Broadcast a transaction
 	BcastTransaction(ctx context.Context, in *BcastTransactionRequest, opts ...grpc.CallOption) (*BcastTransactionResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
-	//SendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.
+	//$pld.category: `Transaction`
+	//$pld.short_description: `Authors, signs, and sends a transaction that outputs some amount to a payment address`
+	//
+	//SendFrom authors, signs, and sends a transaction that outputs some amount to a payment address.
 	SendFrom(ctx context.Context, in *SendFromRequest, opts ...grpc.CallOption) (*SendFromResponse, error)
 }
 
@@ -1461,8 +1470,9 @@ type LightningServer interface {
 	//of the wallet.
 	WalletBalance(context.Context, *WalletBalanceRequest) (*WalletBalanceResponse, error)
 	//
-	//$pld.category: `Wallet`
-	//$pld.short_description: ``
+	//$pld.category: `Address`
+	//$pld.short_description: `Compute and display balances for each address in the wallet`
+	//
 	//GetAddressBalances returns the balance for each of the addresses in the wallet.
 	GetAddressBalances(context.Context, *GetAddressBalancesRequest) (*GetAddressBalancesResponse, error)
 	//
@@ -1473,15 +1483,17 @@ type LightningServer interface {
 	//categorized in local/remote, pending local/remote and unsettled local/remote
 	//balances.
 	ChannelBalance(context.Context, *ChannelBalanceRequest) (*ChannelBalanceResponse, error)
-	// lncli: `listchaintxns`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Transaction`
+	//$pld.short_description: `List transactions from the wallet`
+	//
 	//GetTransactions returns a list describing all the known transactions
 	//relevant to the wallet.
 	GetTransactions(context.Context, *GetTransactionsRequest) (*TransactionDetails, error)
-	// lncli: `estimatefee`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Neutrino`
+	//$pld.short_description: `Get fee estimates for sending bitcoin on-chain to multiple addresses`
+	//
 	//EstimateFee asks the chain backend to estimate the fee rate and total fees
 	//for a transaction that pays to multiple specified outputs.
 	//
@@ -1490,9 +1502,10 @@ type LightningServer interface {
 	//map type doesn't appear in the REST API documentation because of a bug in
 	//the grpc-gateway library.
 	EstimateFee(context.Context, *EstimateFeeRequest) (*EstimateFeeResponse, error)
-	// lncli: `sendcoins`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Transaction`
+	//$pld.short_description: `Send bitcoin on-chain to an address`
+	//
 	//SendCoins executes a request to send coins to a particular address. Unlike
 	//SendMany, this RPC call only allows creating a single output at a time. If
 	//neither target_conf, or sat_per_byte are set, then the internal wallet will
@@ -1500,76 +1513,69 @@ type LightningServer interface {
 	//target.
 	SendCoins(context.Context, *SendCoinsRequest) (*SendCoinsResponse, error)
 	// lncli: `listunspent`
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//Deprecated, use walletrpc.ListUnspent instead.
 	//
 	//ListUnspent returns a list of all utxos spendable by the wallet with a
 	//number of confirmations between the specified minimum and maximum.
 	ListUnspent(context.Context, *ListUnspentRequest) (*ListUnspentResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//SubscribeTransactions creates a uni-directional stream from the server to
 	//the client in which any newly discovered transactions relevant to the
 	//wallet are sent over.
 	SubscribeTransactions(*GetTransactionsRequest, Lightning_SubscribeTransactionsServer) error
-	// lncli: `sendmany`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Transaction`
+	//$pld.short_description: `Send bitcoin on-chain to multiple addresses`
+	//
 	//SendMany handles a request for a transaction that creates multiple specified
 	//outputs in parallel. If neither target_conf, or sat_per_byte are set, then
 	//the internal wallet will consult its fee model to determine a fee for the
 	//default confirmation target.
 	SendMany(context.Context, *SendManyRequest) (*SendManyResponse, error)
-	// lncli: `newaddress`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
 	//NewAddress creates a new address under control of the local wallet.
 	NewAddress(context.Context, *NewAddressRequest) (*NewAddressResponse, error)
-	// lncli: `signmessage`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Address`
+	//$pld.short_description: `Signs a message using the private key of a payment address`
+	//
 	//SignMessage signs a message with this node's private key. The returned
 	//signature string is `zbase32` encoded and pubkey recoverable, meaning that
 	//only the message digest and signature are needed for verification.
 	SignMessage(context.Context, *SignMessageRequest) (*SignMessageResponse, error)
-	// lncli: `connect`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Peer`
+	//$pld.short_description: `Connect to a remote pld peer`
+	//
 	//ConnectPeer attempts to establish a connection to a remote peer. This is at
 	//the networking level, and is used for communication between nodes. This is
 	//distinct from establishing a channel with a peer.
 	ConnectPeer(context.Context, *ConnectPeerRequest) (*ConnectPeerResponse, error)
-	// lncli: `disconnect`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Peer`
+	//$pld.short_description: `Disconnect a remote pld peer identified by public key`
+	//
 	//DisconnectPeer attempts to disconnect one peer from another identified by a
 	//given pubKey. In the case that we currently have a pending or active channel
 	//with the target peer, then this action will be not be allowed.
 	DisconnectPeer(context.Context, *DisconnectPeerRequest) (*DisconnectPeerResponse, error)
-	// lncli: `listpeers`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Peer`
+	//$pld.short_description: `List all active, currently connected peers`
+	//
 	//ListPeers returns a verbose listing of all currently active peers.
 	ListPeers(context.Context, *ListPeersRequest) (*ListPeersResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//SubscribePeerEvents creates a uni-directional stream from the server to
 	//the client in which any events relevant to the state of peers are sent
 	//over. Events include peers going online and offline.
 	SubscribePeerEvents(*PeerEventSubscription, Lightning_SubscribePeerEventsServer) error
-	// lncli: `getinfo`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
 	//GetInfo returns general information concerning the lightning node including
 	//it's identity pubkey, alias, the chains it is connected to, and information
 	//concerning the number of open+pending channels.
 	GetInfo(context.Context, *GetInfoRequest) (*GetInfoResponse, error)
 	//* lncli: `getrecoveryinfo`
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//GetRecoveryInfo returns information concerning the recovery mode including
 	//whether it's in a recovery mode, whether the recovery is finished, and the
 	//progress made so far.
@@ -1623,8 +1629,6 @@ type LightningServer interface {
 	//then be used to manually progress the channel funding flow.
 	OpenChannel(*OpenChannelRequest, Lightning_OpenChannelServer) error
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//FundingStateStep is an advanced funding related call that allows the caller
 	//to either execute some preparatory steps for a funding workflow, or
 	//manually progress a funding workflow. The primary way a funding flow is
@@ -1635,8 +1639,6 @@ type LightningServer interface {
 	//funding for partially complete funding transactions.
 	FundingStateStep(context.Context, *FundingTransitionMsg) (*FundingStateStepResp, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//ChannelAcceptor dispatches a bi-directional streaming RPC in which
 	//OpenChannel requests are sent to the client and the client responds with
 	//a boolean that tells LND whether or not to accept the channel. This allows
@@ -1721,8 +1723,6 @@ type LightningServer interface {
 	//returned.
 	LookupInvoice(context.Context, *PaymentHash) (*Invoice, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
 	//SubscribeInvoices returns a uni-directional stream (server -> client) for
 	//notifying the client of newly added/settled invoices. The caller can
 	//optionally specify the add_index and/or the settle_index. If the add_index
@@ -1806,9 +1806,10 @@ type LightningServer interface {
 	//GetNetworkInfo returns some basic stats about the known channel graph from
 	//the point of view of the node.
 	GetNetworkInfo(context.Context, *NetworkInfoRequest) (*NetworkInfo, error)
-	// lncli: `stop`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Meta`
+	//$pld.short_description: `Stop and shutdown the daemon`
+	//
 	//StopDaemon will send a shutdown request to the interrupt handler, triggering
 	//a graceful shutdown of the daemon.
 	StopDaemon(context.Context, *StopRequest) (*StopResponse, error)
@@ -1820,9 +1821,10 @@ type LightningServer interface {
 	//channels being advertised, updates in the routing policy for a directional
 	//channel edge, and when channels are closed on-chain.
 	SubscribeChannelGraph(*GraphTopologySubscription, Lightning_SubscribeChannelGraphServer) error
-	// lncli: `debuglevel`
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//
+	//$pld.category: `Meta`
+	//$pld.short_description: `Set the debug level`
+	//
 	//DebugLevel allows a caller to programmatically set the logging verbosity of
 	//lnd. The logging can be targeted according to a coarse daemon-wide logging
 	//level, or in a granular fashion to specify the logging for a target
@@ -1902,84 +1904,100 @@ type LightningServer interface {
 	//channel(s) removed.
 	SubscribeChannelBackups(*ChannelBackupSubscription, Lightning_SubscribeChannelBackupsServer) error
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Unspent`
+	//$pld.short_description: `Scan over the chain to find any transactions which may not have been recorded in the wallet's database`
+	//
 	//Scan over the chain to find any transactions which may not have been recorded in the wallet's database
 	ReSync(context.Context, *ReSyncChainRequest) (*ReSyncChainResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Unspent`
+	//$pld.short_description: `Stop a re-synchronization job before it's completion`
+	//
 	//Stop a re-synchronization job before it's completion
 	StopReSync(context.Context, *StopReSyncRequest) (*StopReSyncResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Get the wallet seed words for this wallet`
+	//
 	//Get the wallet seed words for this wallet
 	GetWalletSeed(context.Context, *GetWalletSeedRequest) (*GetWalletSeedResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Seed`
+	//$pld.short_description: `Alter the passphrase which is used to encrypt a wallet seed`
+	//
 	//Change seed's passphrase
 	ChangeSeedPassphrase(context.Context, *ChangeSeedPassphraseRequest) (*ChangeSeedPassphraseResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Get a secret seed`
+	//
 	//Get a secret seed which is generated using the wallet's private key, this can be used as a password for another application
 	GetSecret(context.Context, *GetSecretRequest) (*GetSecretResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Address`
+	//$pld.short_description: `Imports a WIF-encoded private key to the 'imported' account`
+	//
 	//Imports a WIF-encoded private key to the 'imported' account.
 	ImportPrivKey(context.Context, *ImportPrivKeyRequest) (*ImportPrivKeyResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Address`
+	//$pld.short_description: `Returns the private key in WIF encoding that controls some wallet address`
+	//
 	//Returns the private key in WIF encoding that controls some wallet address.
 	DumpPrivKey(context.Context, *DumpPrivKeyRequest) (*DumpPrivKeyResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Lock`
+	//$pld.short_description: `Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session`
+	//
 	//Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.
 	ListLockUnspent(context.Context, *ListLockUnspentRequest) (*ListLockUnspentResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Lock`
+	//$pld.short_description: `Locks or unlocks an unspent output`
+	//
 	//Locks or unlocks an unspent output
 	LockUnspent(context.Context, *LockUnspentRequest) (*LockUnspentResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Transaction`
+	//$pld.short_description: `Create a transaction but do not send it to the chain`
+	//
 	//Create a transaction but po not send it to the chain
 	CreateTransaction(context.Context, *CreateTransactionRequest) (*CreateTransactionResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Address`
+	//$pld.short_description: `Generates a new address`
+	//
 	//Generates and returns a new payment address
 	GetNewAddress(context.Context, *GetNewAddressRequest) (*GetNewAddressResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Transaction`
+	//$pld.short_description: `Returns a JSON object with details regarding a transaction relevant to this wallet`
+	//
 	//Returns a JSON object with details regarding a transaction relevant to this wallet.
 	GetTransaction(context.Context, *GetTransactionRequest) (*GetTransactionResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Network Steward Vote`
+	//$pld.short_description: `Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)`
+	//
 	//Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)
 	SetNetworkStewardVote(context.Context, *SetNetworkStewardVoteRequest) (*SetNetworkStewardVoteResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Network Steward Vote`
+	//$pld.short_description: `Find out how the wallet is currently configured to vote in a network steward election`
+	//
 	//Find out how the wallet is currently configured to vote in a network steward election
 	GetNetworkStewardVote(context.Context, *GetNetworkStewardVoteRequest) (*GetNetworkStewardVoteResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
+	//$pld.category: `Neutrino`
+	//$pld.short_description: `Broadcast a transaction onchain`
+	//
 	//Broadcast a transaction
 	BcastTransaction(context.Context, *BcastTransactionRequest) (*BcastTransactionResponse, error)
 	//
-	//$pld.category: ``
-	//$pld.short_description: ``
-	//SendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.
+	//$pld.category: `Transaction`
+	//$pld.short_description: `Authors, signs, and sends a transaction that outputs some amount to a payment address`
+	//
+	//SendFrom authors, signs, and sends a transaction that outputs some amount to a payment address.
 	SendFrom(context.Context, *SendFromRequest) (*SendFromResponse, error)
 }
 

--- a/lnd/lnrpc/rpc_grpc.pb.go
+++ b/lnd/lnrpc/rpc_grpc.pb.go
@@ -18,24 +18,36 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type LightningClient interface {
-	// lncli: `walletbalance`
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Compute and display the wallet's current balance`
+	//
 	//WalletBalance returns total unspent outputs(confirmed and unconfirmed), all
 	//confirmed unspent outputs and all unconfirmed unspent outputs under control
 	//of the wallet.
 	WalletBalance(ctx context.Context, in *WalletBalanceRequest, opts ...grpc.CallOption) (*WalletBalanceResponse, error)
-	// lncli: `getaddressbalances`
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: ``
 	//GetAddressBalances returns the balance for each of the addresses in the wallet.
 	GetAddressBalances(ctx context.Context, in *GetAddressBalancesRequest, opts ...grpc.CallOption) (*GetAddressBalancesResponse, error)
-	// lncli: `channelbalance`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Returns the sum of the total available channel balance across all open channels`
+	//
 	//ChannelBalance returns a report on the total funds across all open channels,
 	//categorized in local/remote, pending local/remote and unsettled local/remote
 	//balances.
 	ChannelBalance(ctx context.Context, in *ChannelBalanceRequest, opts ...grpc.CallOption) (*ChannelBalanceResponse, error)
 	// lncli: `listchaintxns`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//GetTransactions returns a list describing all the known transactions
 	//relevant to the wallet.
 	GetTransactions(ctx context.Context, in *GetTransactionsRequest, opts ...grpc.CallOption) (*TransactionDetails, error)
 	// lncli: `estimatefee`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//EstimateFee asks the chain backend to estimate the fee rate and total fees
 	//for a transaction that pays to multiple specified outputs.
 	//
@@ -45,6 +57,8 @@ type LightningClient interface {
 	//the grpc-gateway library.
 	EstimateFee(ctx context.Context, in *EstimateFeeRequest, opts ...grpc.CallOption) (*EstimateFeeResponse, error)
 	// lncli: `sendcoins`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SendCoins executes a request to send coins to a particular address. Unlike
 	//SendMany, this RPC call only allows creating a single output at a time. If
 	//neither target_conf, or sat_per_byte are set, then the internal wallet will
@@ -52,65 +66,93 @@ type LightningClient interface {
 	//target.
 	SendCoins(ctx context.Context, in *SendCoinsRequest, opts ...grpc.CallOption) (*SendCoinsResponse, error)
 	// lncli: `listunspent`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Deprecated, use walletrpc.ListUnspent instead.
 	//
 	//ListUnspent returns a list of all utxos spendable by the wallet with a
 	//number of confirmations between the specified minimum and maximum.
 	ListUnspent(ctx context.Context, in *ListUnspentRequest, opts ...grpc.CallOption) (*ListUnspentResponse, error)
 	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SubscribeTransactions creates a uni-directional stream from the server to
 	//the client in which any newly discovered transactions relevant to the
 	//wallet are sent over.
 	SubscribeTransactions(ctx context.Context, in *GetTransactionsRequest, opts ...grpc.CallOption) (Lightning_SubscribeTransactionsClient, error)
 	// lncli: `sendmany`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SendMany handles a request for a transaction that creates multiple specified
 	//outputs in parallel. If neither target_conf, or sat_per_byte are set, then
 	//the internal wallet will consult its fee model to determine a fee for the
 	//default confirmation target.
 	SendMany(ctx context.Context, in *SendManyRequest, opts ...grpc.CallOption) (*SendManyResponse, error)
 	// lncli: `newaddress`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//NewAddress creates a new address under control of the local wallet.
 	NewAddress(ctx context.Context, in *NewAddressRequest, opts ...grpc.CallOption) (*NewAddressResponse, error)
 	// lncli: `signmessage`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SignMessage signs a message with this node's private key. The returned
 	//signature string is `zbase32` encoded and pubkey recoverable, meaning that
 	//only the message digest and signature are needed for verification.
 	SignMessage(ctx context.Context, in *SignMessageRequest, opts ...grpc.CallOption) (*SignMessageResponse, error)
 	// lncli: `connect`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//ConnectPeer attempts to establish a connection to a remote peer. This is at
 	//the networking level, and is used for communication between nodes. This is
 	//distinct from establishing a channel with a peer.
 	ConnectPeer(ctx context.Context, in *ConnectPeerRequest, opts ...grpc.CallOption) (*ConnectPeerResponse, error)
 	// lncli: `disconnect`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//DisconnectPeer attempts to disconnect one peer from another identified by a
 	//given pubKey. In the case that we currently have a pending or active channel
 	//with the target peer, then this action will be not be allowed.
 	DisconnectPeer(ctx context.Context, in *DisconnectPeerRequest, opts ...grpc.CallOption) (*DisconnectPeerResponse, error)
 	// lncli: `listpeers`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//ListPeers returns a verbose listing of all currently active peers.
 	ListPeers(ctx context.Context, in *ListPeersRequest, opts ...grpc.CallOption) (*ListPeersResponse, error)
 	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SubscribePeerEvents creates a uni-directional stream from the server to
 	//the client in which any events relevant to the state of peers are sent
 	//over. Events include peers going online and offline.
 	SubscribePeerEvents(ctx context.Context, in *PeerEventSubscription, opts ...grpc.CallOption) (Lightning_SubscribePeerEventsClient, error)
 	// lncli: `getinfo`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//GetInfo returns general information concerning the lightning node including
 	//it's identity pubkey, alias, the chains it is connected to, and information
 	//concerning the number of open+pending channels.
 	GetInfo(ctx context.Context, in *GetInfoRequest, opts ...grpc.CallOption) (*GetInfoResponse, error)
 	//* lncli: `getrecoveryinfo`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//GetRecoveryInfo returns information concerning the recovery mode including
 	//whether it's in a recovery mode, whether the recovery is finished, and the
 	//progress made so far.
 	GetRecoveryInfo(ctx context.Context, in *GetRecoveryInfoRequest, opts ...grpc.CallOption) (*GetRecoveryInfoResponse, error)
-	// lncli: `pendingchannels`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Display information pertaining to pending channels`
+	//
 	//PendingChannels returns a list of all the channels that are currently
 	//considered "pending". A channel is pending if it has finished the funding
 	//workflow and is waiting for confirmations for the funding txn, or is in the
 	//process of closure, either initiated cooperatively or non-cooperatively.
 	PendingChannels(ctx context.Context, in *PendingChannelsRequest, opts ...grpc.CallOption) (*PendingChannelsResponse, error)
-	// lncli: `listchannels`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `List all open channels`
+	//
 	//ListChannels returns a description of all the open channels that this node
 	//is a participant in.
 	ListChannels(ctx context.Context, in *ListChannelsRequest, opts ...grpc.CallOption) (*ListChannelsResponse, error)
@@ -120,7 +162,10 @@ type LightningClient interface {
 	//sent over. Events include new active channels, inactive channels, and closed
 	//channels.
 	SubscribeChannelEvents(ctx context.Context, in *ChannelEventSubscription, opts ...grpc.CallOption) (Lightning_SubscribeChannelEventsClient, error)
-	// lncli: `closedchannels`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `List all closed channels`
+	//
 	//ClosedChannels returns a description of all the closed channels that
 	//this node was a participant in.
 	ClosedChannels(ctx context.Context, in *ClosedChannelsRequest, opts ...grpc.CallOption) (*ClosedChannelsResponse, error)
@@ -130,7 +175,10 @@ type LightningClient interface {
 	//other sync calls, all byte slices are intended to be populated as hex
 	//encoded strings.
 	OpenChannelSync(ctx context.Context, in *OpenChannelRequest, opts ...grpc.CallOption) (*ChannelPoint, error)
-	// lncli: `openchannel`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Open a channel to a node or an existing peer`
+	//
 	//OpenChannel attempts to open a singly funded channel specified in the
 	//request to a remote peer. Users are able to specify a target number of
 	//blocks that the funding transaction should be confirmed in, or a manual fee
@@ -141,6 +189,8 @@ type LightningClient interface {
 	//then be used to manually progress the channel funding flow.
 	OpenChannel(ctx context.Context, in *OpenChannelRequest, opts ...grpc.CallOption) (Lightning_OpenChannelClient, error)
 	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//FundingStateStep is an advanced funding related call that allows the caller
 	//to either execute some preparatory steps for a funding workflow, or
 	//manually progress a funding workflow. The primary way a funding flow is
@@ -151,13 +201,18 @@ type LightningClient interface {
 	//funding for partially complete funding transactions.
 	FundingStateStep(ctx context.Context, in *FundingTransitionMsg, opts ...grpc.CallOption) (*FundingStateStepResp, error)
 	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//ChannelAcceptor dispatches a bi-directional streaming RPC in which
 	//OpenChannel requests are sent to the client and the client responds with
 	//a boolean that tells LND whether or not to accept the channel. This allows
 	//node operators to specify their own criteria for accepting inbound channels
 	//through a single persistent connection.
 	ChannelAcceptor(ctx context.Context, opts ...grpc.CallOption) (Lightning_ChannelAcceptorClient, error)
-	// lncli: `closechannel`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Close an existing channel`
+	//
 	//CloseChannel attempts to close an active channel identified by its channel
 	//outpoint (ChannelPoint). The actions of this method can additionally be
 	//augmented to attempt a force close after a timeout period in the case of an
@@ -166,7 +221,10 @@ type LightningClient interface {
 	//closure transaction is confirmed, or a manual fee rate. If neither are
 	//specified, then a default lax, block confirmation target is used.
 	CloseChannel(ctx context.Context, in *CloseChannelRequest, opts ...grpc.CallOption) (Lightning_CloseChannelClient, error)
-	// lncli: `abandonchannel`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Abandons an existing channel`
+	//
 	//AbandonChannel removes all channel state from the database except for a
 	//close summary. This method can be used to get rid of permanently unusable
 	//channels due to bugs fixed in newer versions of lnd. This method can also be
@@ -175,7 +233,7 @@ type LightningClient interface {
 	//build.
 	AbandonChannel(ctx context.Context, in *AbandonChannelRequest, opts ...grpc.CallOption) (*AbandonChannelResponse, error)
 	// Deprecated: Do not use.
-	// lncli: `sendpayment`
+	//
 	//Deprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a
 	//bi-directional streaming RPC for sending payments through the Lightning
 	//Network. A single RPC invocation creates a persistent bi-directional
@@ -200,12 +258,18 @@ type LightningClient interface {
 	//SendToRouteSync is a synchronous version of SendToRoute. It Will block
 	//until the payment either fails or succeeds.
 	SendToRouteSync(ctx context.Context, in *SendToRouteRequest, opts ...grpc.CallOption) (*SendResponse, error)
-	// lncli: `addinvoice`
+	//
+	//$pld.category: `Invoice`
+	//$pld.short_description: `Add a new invoice`
+	//
 	//AddInvoice attempts to add a new invoice to the invoice database. Any
 	//duplicated invoices are rejected, therefore all invoices *must* have a
 	//unique payment preimage.
 	AddInvoice(ctx context.Context, in *Invoice, opts ...grpc.CallOption) (*AddInvoiceResponse, error)
-	// lncli: `listinvoices`
+	//
+	//$pld.category: `Invoice`
+	//$pld.short_description: `List all invoices currently stored within the database. Any active debug invoices are ignored`
+	//
 	//ListInvoices returns a list of all the invoices currently stored within the
 	//database. Any active debug invoices are ignored. It has full support for
 	//paginated responses, allowing users to query for specific invoices through
@@ -214,12 +278,17 @@ type LightningClient interface {
 	//next request. By default, the first 100 invoices created will be returned.
 	//Backwards pagination is also supported through the Reversed flag.
 	ListInvoices(ctx context.Context, in *ListInvoiceRequest, opts ...grpc.CallOption) (*ListInvoiceResponse, error)
-	// lncli: `lookupinvoice`
+	//
+	//$pld.category: `Invoice`
+	//$pld.short_description: `Lookup an existing invoice by its payment hash`
+	//
 	//LookupInvoice attempts to look up an invoice according to its payment hash.
 	//The passed payment hash *must* be exactly 32 bytes, if not, an error is
 	//returned.
 	LookupInvoice(ctx context.Context, in *PaymentHash, opts ...grpc.CallOption) (*Invoice, error)
 	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SubscribeInvoices returns a uni-directional stream (server -> client) for
 	//notifying the client of newly added/settled invoices. The caller can
 	//optionally specify the add_index and/or the settle_index. If the add_index
@@ -230,18 +299,27 @@ type LightningClient interface {
 	//of these fields can be set. If no fields are set, then we'll only send out
 	//the latest add/settle events.
 	SubscribeInvoices(ctx context.Context, in *InvoiceSubscription, opts ...grpc.CallOption) (Lightning_SubscribeInvoicesClient, error)
-	// lncli: `decodepayreq`
+	//
+	//$pld.category: `Invoice`
+	//$pld.short_description: `Decode a payment request`
+	//
 	//DecodePayReq takes an encoded payment request string and attempts to decode
 	//it, returning a full description of the conditions encoded within the
 	//payment request.
 	DecodePayReq(ctx context.Context, in *PayReqString, opts ...grpc.CallOption) (*PayReq, error)
-	// lncli: `listpayments`
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `List all outgoing payments`
+	//
 	//ListPayments returns a list of all outgoing payments.
 	ListPayments(ctx context.Context, in *ListPaymentsRequest, opts ...grpc.CallOption) (*ListPaymentsResponse, error)
 	//
 	//DeleteAllPayments deletes all outgoing payments from DB.
 	DeleteAllPayments(ctx context.Context, in *DeleteAllPaymentsRequest, opts ...grpc.CallOption) (*DeleteAllPaymentsResponse, error)
-	// lncli: `describegraph`
+	//
+	//$pld.category: `Graph`
+	//$pld.short_description: `Describe the network graph`
+	//
 	//DescribeGraph returns a description of the latest graph state from the
 	//point of view of the node. The graph information is partitioned into two
 	//components: all the nodes/vertexes, and all the edges that connect the
@@ -249,21 +327,33 @@ type LightningClient interface {
 	//the node directional specific routing policy which includes: the time lock
 	//delta, fee information, etc.
 	DescribeGraph(ctx context.Context, in *ChannelGraphRequest, opts ...grpc.CallOption) (*ChannelGraph, error)
-	// lncli: `getnodemetrics`
+	//
+	//$pld.category: `Graph`
+	//$pld.short_description: `Get node metrics`
+	//
 	//GetNodeMetrics returns node metrics calculated from the graph. Currently
 	//the only supported metric is betweenness centrality of individual nodes.
 	GetNodeMetrics(ctx context.Context, in *NodeMetricsRequest, opts ...grpc.CallOption) (*NodeMetricsResponse, error)
-	// lncli: `getchaninfo`
+	//
+	//$pld.category: `Graph`
+	//$pld.short_description: `Get the state of a channel`
+	//
 	//GetChanInfo returns the latest authenticated network announcement for the
 	//given channel identified by its channel ID: an 8-byte integer which
 	//uniquely identifies the location of transaction's funding output within the
 	//blockchain.
 	GetChanInfo(ctx context.Context, in *ChanInfoRequest, opts ...grpc.CallOption) (*ChannelEdge, error)
-	// lncli: `getnodeinfo`
+	//
+	//$pld.category: `Graph`
+	//$pld.short_description: `Get information on a specific node`
+	//
 	//GetNodeInfo returns the latest advertised, aggregated, and authenticated
 	//channel information for the specified node identified by its public key.
 	GetNodeInfo(ctx context.Context, in *NodeInfoRequest, opts ...grpc.CallOption) (*NodeInfo, error)
-	// lncli: `queryroutes`
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Query a route to a destination`
+	//
 	//QueryRoutes attempts to query the daemon's Channel Router for a possible
 	//route to a target destination capable of carrying a specific amount of
 	//satoshis. The returned route contains the full details required to craft and
@@ -275,11 +365,16 @@ type LightningClient interface {
 	//to the URL. Unfortunately this map type doesn't appear in the REST API
 	//documentation because of a bug in the grpc-gateway library.
 	QueryRoutes(ctx context.Context, in *QueryRoutesRequest, opts ...grpc.CallOption) (*QueryRoutesResponse, error)
-	// lncli: `getnetworkinfo`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Get statistical information about the current state of the network`
+	//
 	//GetNetworkInfo returns some basic stats about the known channel graph from
 	//the point of view of the node.
 	GetNetworkInfo(ctx context.Context, in *NetworkInfoRequest, opts ...grpc.CallOption) (*NetworkInfo, error)
 	// lncli: `stop`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//StopDaemon will send a shutdown request to the interrupt handler, triggering
 	//a graceful shutdown of the daemon.
 	StopDaemon(ctx context.Context, in *StopRequest, opts ...grpc.CallOption) (*StopResponse, error)
@@ -292,20 +387,31 @@ type LightningClient interface {
 	//channel edge, and when channels are closed on-chain.
 	SubscribeChannelGraph(ctx context.Context, in *GraphTopologySubscription, opts ...grpc.CallOption) (Lightning_SubscribeChannelGraphClient, error)
 	// lncli: `debuglevel`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//DebugLevel allows a caller to programmatically set the logging verbosity of
 	//lnd. The logging can be targeted according to a coarse daemon-wide logging
 	//level, or in a granular fashion to specify the logging for a target
 	//sub-system.
 	DebugLevel(ctx context.Context, in *DebugLevelRequest, opts ...grpc.CallOption) (*DebugLevelResponse, error)
-	// lncli: `feereport`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Display the current fee policies of all active channels`
+	//
 	//FeeReport allows the caller to obtain a report detailing the current fee
 	//schedule enforced by the node globally for each channel.
 	FeeReport(ctx context.Context, in *FeeReportRequest, opts ...grpc.CallOption) (*FeeReportResponse, error)
-	// lncli: `updatechanpolicy`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Update the channel policy for all channels, or a single channel`
+	//
 	//UpdateChannelPolicy allows the caller to update the fee schedule and
 	//channel policies for all channels globally, or a particular channel.
 	UpdateChannelPolicy(ctx context.Context, in *PolicyUpdateRequest, opts ...grpc.CallOption) (*PolicyUpdateResponse, error)
-	// lncli: `fwdinghistory`
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Query the history of all forwarded HTLCs`
+	//
 	//ForwardingHistory allows the caller to query the htlcswitch for a record of
 	//all HTLCs forwarded within the target time range, and integer offset
 	//within that time range. If no time-range is specified, then the first chunk
@@ -317,7 +423,10 @@ type LightningClient interface {
 	//the index offset of the last entry. The index offset can be provided to the
 	//request to allow the caller to skip a series of records.
 	ForwardingHistory(ctx context.Context, in *ForwardingHistoryRequest, opts ...grpc.CallOption) (*ForwardingHistoryResponse, error)
-	// lncli: `exportchanbackup`
+	//
+	//$pld.category: `Backup`
+	//$pld.short_description: `Obtain a static channel back up for a selected channels, or all known channels`
+	//
 	//ExportChannelBackup attempts to return an encrypted static channel backup
 	//for the target channel identified by it channel point. The backup is
 	//encrypted with a key generated from the aezeed seed of the user. The
@@ -333,11 +442,17 @@ type LightningClient interface {
 	//each channel.
 	ExportAllChannelBackups(ctx context.Context, in *ChanBackupExportRequest, opts ...grpc.CallOption) (*ChanBackupSnapshot, error)
 	//
+	//$pld.category: `Backup`
+	//$pld.short_description: `Verify an existing channel backup`
+	//
 	//VerifyChanBackup allows a caller to verify the integrity of a channel backup
 	//snapshot. This method will accept either a packed Single or a packed Multi.
 	//Specifying both will result in an error.
 	VerifyChanBackup(ctx context.Context, in *ChanBackupSnapshot, opts ...grpc.CallOption) (*VerifyChanBackupResponse, error)
-	// lncli: `restorechanbackup`
+	//
+	//$pld.category: `Backup`
+	//$pld.short_description: `Restore an existing single or multi-channel static channel backup`
+	//
 	//RestoreChannelBackups accepts a set of singular channel backups, or a
 	//single encrypted multi-chan backup and attempts to recover any funds
 	//remaining within the channel. If we are able to unpack the backup, then the
@@ -352,36 +467,84 @@ type LightningClient interface {
 	//ups, but the updated set of encrypted multi-chan backups with the closed
 	//channel(s) removed.
 	SubscribeChannelBackups(ctx context.Context, in *ChannelBackupSubscription, opts ...grpc.CallOption) (Lightning_SubscribeChannelBackupsClient, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Scan over the chain to find any transactions which may not have been recorded in the wallet's database
 	ReSync(ctx context.Context, in *ReSyncChainRequest, opts ...grpc.CallOption) (*ReSyncChainResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Stop a re-synchronization job before it's completion
 	StopReSync(ctx context.Context, in *StopReSyncRequest, opts ...grpc.CallOption) (*StopReSyncResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Get the wallet seed words for this wallet
 	GetWalletSeed(ctx context.Context, in *GetWalletSeedRequest, opts ...grpc.CallOption) (*GetWalletSeedResponse, error)
-	//  Change seed's passphrase
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
+	//Change seed's passphrase
 	ChangeSeedPassphrase(ctx context.Context, in *ChangeSeedPassphraseRequest, opts ...grpc.CallOption) (*ChangeSeedPassphraseResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Get a secret seed which is generated using the wallet's private key, this can be used as a password for another application
 	GetSecret(ctx context.Context, in *GetSecretRequest, opts ...grpc.CallOption) (*GetSecretResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Imports a WIF-encoded private key to the 'imported' account.
 	ImportPrivKey(ctx context.Context, in *ImportPrivKeyRequest, opts ...grpc.CallOption) (*ImportPrivKeyResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Returns the private key in WIF encoding that controls some wallet address.
 	DumpPrivKey(ctx context.Context, in *DumpPrivKeyRequest, opts ...grpc.CallOption) (*DumpPrivKeyResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.
 	ListLockUnspent(ctx context.Context, in *ListLockUnspentRequest, opts ...grpc.CallOption) (*ListLockUnspentResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Locks or unlocks an unspent output
 	LockUnspent(ctx context.Context, in *LockUnspentRequest, opts ...grpc.CallOption) (*LockUnspentResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Create a transaction but po not send it to the chain
 	CreateTransaction(ctx context.Context, in *CreateTransactionRequest, opts ...grpc.CallOption) (*CreateTransactionResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Generates and returns a new payment address
 	GetNewAddress(ctx context.Context, in *GetNewAddressRequest, opts ...grpc.CallOption) (*GetNewAddressResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Returns a JSON object with details regarding a transaction relevant to this wallet.
 	GetTransaction(ctx context.Context, in *GetTransactionRequest, opts ...grpc.CallOption) (*GetTransactionResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)
 	SetNetworkStewardVote(ctx context.Context, in *SetNetworkStewardVoteRequest, opts ...grpc.CallOption) (*SetNetworkStewardVoteResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Find out how the wallet is currently configured to vote in a network steward election
 	GetNetworkStewardVote(ctx context.Context, in *GetNetworkStewardVoteRequest, opts ...grpc.CallOption) (*GetNetworkStewardVoteResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Broadcast a transaction
 	BcastTransaction(ctx context.Context, in *BcastTransactionRequest, opts ...grpc.CallOption) (*BcastTransactionResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.
 	SendFrom(ctx context.Context, in *SendFromRequest, opts ...grpc.CallOption) (*SendFromResponse, error)
 }
@@ -1289,24 +1452,36 @@ func (c *lightningClient) SendFrom(ctx context.Context, in *SendFromRequest, opt
 // All implementations should embed UnimplementedLightningServer
 // for forward compatibility
 type LightningServer interface {
-	// lncli: `walletbalance`
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Compute and display the wallet's current balance`
+	//
 	//WalletBalance returns total unspent outputs(confirmed and unconfirmed), all
 	//confirmed unspent outputs and all unconfirmed unspent outputs under control
 	//of the wallet.
 	WalletBalance(context.Context, *WalletBalanceRequest) (*WalletBalanceResponse, error)
-	// lncli: `getaddressbalances`
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: ``
 	//GetAddressBalances returns the balance for each of the addresses in the wallet.
 	GetAddressBalances(context.Context, *GetAddressBalancesRequest) (*GetAddressBalancesResponse, error)
-	// lncli: `channelbalance`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Returns the sum of the total available channel balance across all open channels`
+	//
 	//ChannelBalance returns a report on the total funds across all open channels,
 	//categorized in local/remote, pending local/remote and unsettled local/remote
 	//balances.
 	ChannelBalance(context.Context, *ChannelBalanceRequest) (*ChannelBalanceResponse, error)
 	// lncli: `listchaintxns`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//GetTransactions returns a list describing all the known transactions
 	//relevant to the wallet.
 	GetTransactions(context.Context, *GetTransactionsRequest) (*TransactionDetails, error)
 	// lncli: `estimatefee`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//EstimateFee asks the chain backend to estimate the fee rate and total fees
 	//for a transaction that pays to multiple specified outputs.
 	//
@@ -1316,6 +1491,8 @@ type LightningServer interface {
 	//the grpc-gateway library.
 	EstimateFee(context.Context, *EstimateFeeRequest) (*EstimateFeeResponse, error)
 	// lncli: `sendcoins`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SendCoins executes a request to send coins to a particular address. Unlike
 	//SendMany, this RPC call only allows creating a single output at a time. If
 	//neither target_conf, or sat_per_byte are set, then the internal wallet will
@@ -1323,65 +1500,93 @@ type LightningServer interface {
 	//target.
 	SendCoins(context.Context, *SendCoinsRequest) (*SendCoinsResponse, error)
 	// lncli: `listunspent`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Deprecated, use walletrpc.ListUnspent instead.
 	//
 	//ListUnspent returns a list of all utxos spendable by the wallet with a
 	//number of confirmations between the specified minimum and maximum.
 	ListUnspent(context.Context, *ListUnspentRequest) (*ListUnspentResponse, error)
 	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SubscribeTransactions creates a uni-directional stream from the server to
 	//the client in which any newly discovered transactions relevant to the
 	//wallet are sent over.
 	SubscribeTransactions(*GetTransactionsRequest, Lightning_SubscribeTransactionsServer) error
 	// lncli: `sendmany`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SendMany handles a request for a transaction that creates multiple specified
 	//outputs in parallel. If neither target_conf, or sat_per_byte are set, then
 	//the internal wallet will consult its fee model to determine a fee for the
 	//default confirmation target.
 	SendMany(context.Context, *SendManyRequest) (*SendManyResponse, error)
 	// lncli: `newaddress`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//NewAddress creates a new address under control of the local wallet.
 	NewAddress(context.Context, *NewAddressRequest) (*NewAddressResponse, error)
 	// lncli: `signmessage`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SignMessage signs a message with this node's private key. The returned
 	//signature string is `zbase32` encoded and pubkey recoverable, meaning that
 	//only the message digest and signature are needed for verification.
 	SignMessage(context.Context, *SignMessageRequest) (*SignMessageResponse, error)
 	// lncli: `connect`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//ConnectPeer attempts to establish a connection to a remote peer. This is at
 	//the networking level, and is used for communication between nodes. This is
 	//distinct from establishing a channel with a peer.
 	ConnectPeer(context.Context, *ConnectPeerRequest) (*ConnectPeerResponse, error)
 	// lncli: `disconnect`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//DisconnectPeer attempts to disconnect one peer from another identified by a
 	//given pubKey. In the case that we currently have a pending or active channel
 	//with the target peer, then this action will be not be allowed.
 	DisconnectPeer(context.Context, *DisconnectPeerRequest) (*DisconnectPeerResponse, error)
 	// lncli: `listpeers`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//ListPeers returns a verbose listing of all currently active peers.
 	ListPeers(context.Context, *ListPeersRequest) (*ListPeersResponse, error)
 	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SubscribePeerEvents creates a uni-directional stream from the server to
 	//the client in which any events relevant to the state of peers are sent
 	//over. Events include peers going online and offline.
 	SubscribePeerEvents(*PeerEventSubscription, Lightning_SubscribePeerEventsServer) error
 	// lncli: `getinfo`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//GetInfo returns general information concerning the lightning node including
 	//it's identity pubkey, alias, the chains it is connected to, and information
 	//concerning the number of open+pending channels.
 	GetInfo(context.Context, *GetInfoRequest) (*GetInfoResponse, error)
 	//* lncli: `getrecoveryinfo`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//GetRecoveryInfo returns information concerning the recovery mode including
 	//whether it's in a recovery mode, whether the recovery is finished, and the
 	//progress made so far.
 	GetRecoveryInfo(context.Context, *GetRecoveryInfoRequest) (*GetRecoveryInfoResponse, error)
-	// lncli: `pendingchannels`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Display information pertaining to pending channels`
+	//
 	//PendingChannels returns a list of all the channels that are currently
 	//considered "pending". A channel is pending if it has finished the funding
 	//workflow and is waiting for confirmations for the funding txn, or is in the
 	//process of closure, either initiated cooperatively or non-cooperatively.
 	PendingChannels(context.Context, *PendingChannelsRequest) (*PendingChannelsResponse, error)
-	// lncli: `listchannels`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `List all open channels`
+	//
 	//ListChannels returns a description of all the open channels that this node
 	//is a participant in.
 	ListChannels(context.Context, *ListChannelsRequest) (*ListChannelsResponse, error)
@@ -1391,7 +1596,10 @@ type LightningServer interface {
 	//sent over. Events include new active channels, inactive channels, and closed
 	//channels.
 	SubscribeChannelEvents(*ChannelEventSubscription, Lightning_SubscribeChannelEventsServer) error
-	// lncli: `closedchannels`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `List all closed channels`
+	//
 	//ClosedChannels returns a description of all the closed channels that
 	//this node was a participant in.
 	ClosedChannels(context.Context, *ClosedChannelsRequest) (*ClosedChannelsResponse, error)
@@ -1401,7 +1609,10 @@ type LightningServer interface {
 	//other sync calls, all byte slices are intended to be populated as hex
 	//encoded strings.
 	OpenChannelSync(context.Context, *OpenChannelRequest) (*ChannelPoint, error)
-	// lncli: `openchannel`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Open a channel to a node or an existing peer`
+	//
 	//OpenChannel attempts to open a singly funded channel specified in the
 	//request to a remote peer. Users are able to specify a target number of
 	//blocks that the funding transaction should be confirmed in, or a manual fee
@@ -1412,6 +1623,8 @@ type LightningServer interface {
 	//then be used to manually progress the channel funding flow.
 	OpenChannel(*OpenChannelRequest, Lightning_OpenChannelServer) error
 	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//FundingStateStep is an advanced funding related call that allows the caller
 	//to either execute some preparatory steps for a funding workflow, or
 	//manually progress a funding workflow. The primary way a funding flow is
@@ -1422,13 +1635,18 @@ type LightningServer interface {
 	//funding for partially complete funding transactions.
 	FundingStateStep(context.Context, *FundingTransitionMsg) (*FundingStateStepResp, error)
 	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//ChannelAcceptor dispatches a bi-directional streaming RPC in which
 	//OpenChannel requests are sent to the client and the client responds with
 	//a boolean that tells LND whether or not to accept the channel. This allows
 	//node operators to specify their own criteria for accepting inbound channels
 	//through a single persistent connection.
 	ChannelAcceptor(Lightning_ChannelAcceptorServer) error
-	// lncli: `closechannel`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Close an existing channel`
+	//
 	//CloseChannel attempts to close an active channel identified by its channel
 	//outpoint (ChannelPoint). The actions of this method can additionally be
 	//augmented to attempt a force close after a timeout period in the case of an
@@ -1437,7 +1655,10 @@ type LightningServer interface {
 	//closure transaction is confirmed, or a manual fee rate. If neither are
 	//specified, then a default lax, block confirmation target is used.
 	CloseChannel(*CloseChannelRequest, Lightning_CloseChannelServer) error
-	// lncli: `abandonchannel`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Abandons an existing channel`
+	//
 	//AbandonChannel removes all channel state from the database except for a
 	//close summary. This method can be used to get rid of permanently unusable
 	//channels due to bugs fixed in newer versions of lnd. This method can also be
@@ -1446,7 +1667,7 @@ type LightningServer interface {
 	//build.
 	AbandonChannel(context.Context, *AbandonChannelRequest) (*AbandonChannelResponse, error)
 	// Deprecated: Do not use.
-	// lncli: `sendpayment`
+	//
 	//Deprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a
 	//bi-directional streaming RPC for sending payments through the Lightning
 	//Network. A single RPC invocation creates a persistent bi-directional
@@ -1471,12 +1692,18 @@ type LightningServer interface {
 	//SendToRouteSync is a synchronous version of SendToRoute. It Will block
 	//until the payment either fails or succeeds.
 	SendToRouteSync(context.Context, *SendToRouteRequest) (*SendResponse, error)
-	// lncli: `addinvoice`
+	//
+	//$pld.category: `Invoice`
+	//$pld.short_description: `Add a new invoice`
+	//
 	//AddInvoice attempts to add a new invoice to the invoice database. Any
 	//duplicated invoices are rejected, therefore all invoices *must* have a
 	//unique payment preimage.
 	AddInvoice(context.Context, *Invoice) (*AddInvoiceResponse, error)
-	// lncli: `listinvoices`
+	//
+	//$pld.category: `Invoice`
+	//$pld.short_description: `List all invoices currently stored within the database. Any active debug invoices are ignored`
+	//
 	//ListInvoices returns a list of all the invoices currently stored within the
 	//database. Any active debug invoices are ignored. It has full support for
 	//paginated responses, allowing users to query for specific invoices through
@@ -1485,12 +1712,17 @@ type LightningServer interface {
 	//next request. By default, the first 100 invoices created will be returned.
 	//Backwards pagination is also supported through the Reversed flag.
 	ListInvoices(context.Context, *ListInvoiceRequest) (*ListInvoiceResponse, error)
-	// lncli: `lookupinvoice`
+	//
+	//$pld.category: `Invoice`
+	//$pld.short_description: `Lookup an existing invoice by its payment hash`
+	//
 	//LookupInvoice attempts to look up an invoice according to its payment hash.
 	//The passed payment hash *must* be exactly 32 bytes, if not, an error is
 	//returned.
 	LookupInvoice(context.Context, *PaymentHash) (*Invoice, error)
 	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SubscribeInvoices returns a uni-directional stream (server -> client) for
 	//notifying the client of newly added/settled invoices. The caller can
 	//optionally specify the add_index and/or the settle_index. If the add_index
@@ -1501,18 +1733,27 @@ type LightningServer interface {
 	//of these fields can be set. If no fields are set, then we'll only send out
 	//the latest add/settle events.
 	SubscribeInvoices(*InvoiceSubscription, Lightning_SubscribeInvoicesServer) error
-	// lncli: `decodepayreq`
+	//
+	//$pld.category: `Invoice`
+	//$pld.short_description: `Decode a payment request`
+	//
 	//DecodePayReq takes an encoded payment request string and attempts to decode
 	//it, returning a full description of the conditions encoded within the
 	//payment request.
 	DecodePayReq(context.Context, *PayReqString) (*PayReq, error)
-	// lncli: `listpayments`
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `List all outgoing payments`
+	//
 	//ListPayments returns a list of all outgoing payments.
 	ListPayments(context.Context, *ListPaymentsRequest) (*ListPaymentsResponse, error)
 	//
 	//DeleteAllPayments deletes all outgoing payments from DB.
 	DeleteAllPayments(context.Context, *DeleteAllPaymentsRequest) (*DeleteAllPaymentsResponse, error)
-	// lncli: `describegraph`
+	//
+	//$pld.category: `Graph`
+	//$pld.short_description: `Describe the network graph`
+	//
 	//DescribeGraph returns a description of the latest graph state from the
 	//point of view of the node. The graph information is partitioned into two
 	//components: all the nodes/vertexes, and all the edges that connect the
@@ -1520,21 +1761,33 @@ type LightningServer interface {
 	//the node directional specific routing policy which includes: the time lock
 	//delta, fee information, etc.
 	DescribeGraph(context.Context, *ChannelGraphRequest) (*ChannelGraph, error)
-	// lncli: `getnodemetrics`
+	//
+	//$pld.category: `Graph`
+	//$pld.short_description: `Get node metrics`
+	//
 	//GetNodeMetrics returns node metrics calculated from the graph. Currently
 	//the only supported metric is betweenness centrality of individual nodes.
 	GetNodeMetrics(context.Context, *NodeMetricsRequest) (*NodeMetricsResponse, error)
-	// lncli: `getchaninfo`
+	//
+	//$pld.category: `Graph`
+	//$pld.short_description: `Get the state of a channel`
+	//
 	//GetChanInfo returns the latest authenticated network announcement for the
 	//given channel identified by its channel ID: an 8-byte integer which
 	//uniquely identifies the location of transaction's funding output within the
 	//blockchain.
 	GetChanInfo(context.Context, *ChanInfoRequest) (*ChannelEdge, error)
-	// lncli: `getnodeinfo`
+	//
+	//$pld.category: `Graph`
+	//$pld.short_description: `Get information on a specific node`
+	//
 	//GetNodeInfo returns the latest advertised, aggregated, and authenticated
 	//channel information for the specified node identified by its public key.
 	GetNodeInfo(context.Context, *NodeInfoRequest) (*NodeInfo, error)
-	// lncli: `queryroutes`
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Query a route to a destination`
+	//
 	//QueryRoutes attempts to query the daemon's Channel Router for a possible
 	//route to a target destination capable of carrying a specific amount of
 	//satoshis. The returned route contains the full details required to craft and
@@ -1546,11 +1799,16 @@ type LightningServer interface {
 	//to the URL. Unfortunately this map type doesn't appear in the REST API
 	//documentation because of a bug in the grpc-gateway library.
 	QueryRoutes(context.Context, *QueryRoutesRequest) (*QueryRoutesResponse, error)
-	// lncli: `getnetworkinfo`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Get statistical information about the current state of the network`
+	//
 	//GetNetworkInfo returns some basic stats about the known channel graph from
 	//the point of view of the node.
 	GetNetworkInfo(context.Context, *NetworkInfoRequest) (*NetworkInfo, error)
 	// lncli: `stop`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//StopDaemon will send a shutdown request to the interrupt handler, triggering
 	//a graceful shutdown of the daemon.
 	StopDaemon(context.Context, *StopRequest) (*StopResponse, error)
@@ -1563,20 +1821,31 @@ type LightningServer interface {
 	//channel edge, and when channels are closed on-chain.
 	SubscribeChannelGraph(*GraphTopologySubscription, Lightning_SubscribeChannelGraphServer) error
 	// lncli: `debuglevel`
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//DebugLevel allows a caller to programmatically set the logging verbosity of
 	//lnd. The logging can be targeted according to a coarse daemon-wide logging
 	//level, or in a granular fashion to specify the logging for a target
 	//sub-system.
 	DebugLevel(context.Context, *DebugLevelRequest) (*DebugLevelResponse, error)
-	// lncli: `feereport`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Display the current fee policies of all active channels`
+	//
 	//FeeReport allows the caller to obtain a report detailing the current fee
 	//schedule enforced by the node globally for each channel.
 	FeeReport(context.Context, *FeeReportRequest) (*FeeReportResponse, error)
-	// lncli: `updatechanpolicy`
+	//
+	//$pld.category: `Channel`
+	//$pld.short_description: `Update the channel policy for all channels, or a single channel`
+	//
 	//UpdateChannelPolicy allows the caller to update the fee schedule and
 	//channel policies for all channels globally, or a particular channel.
 	UpdateChannelPolicy(context.Context, *PolicyUpdateRequest) (*PolicyUpdateResponse, error)
-	// lncli: `fwdinghistory`
+	//
+	//$pld.category: `Payment`
+	//$pld.short_description: `Query the history of all forwarded HTLCs`
+	//
 	//ForwardingHistory allows the caller to query the htlcswitch for a record of
 	//all HTLCs forwarded within the target time range, and integer offset
 	//within that time range. If no time-range is specified, then the first chunk
@@ -1588,7 +1857,10 @@ type LightningServer interface {
 	//the index offset of the last entry. The index offset can be provided to the
 	//request to allow the caller to skip a series of records.
 	ForwardingHistory(context.Context, *ForwardingHistoryRequest) (*ForwardingHistoryResponse, error)
-	// lncli: `exportchanbackup`
+	//
+	//$pld.category: `Backup`
+	//$pld.short_description: `Obtain a static channel back up for a selected channels, or all known channels`
+	//
 	//ExportChannelBackup attempts to return an encrypted static channel backup
 	//for the target channel identified by it channel point. The backup is
 	//encrypted with a key generated from the aezeed seed of the user. The
@@ -1604,11 +1876,17 @@ type LightningServer interface {
 	//each channel.
 	ExportAllChannelBackups(context.Context, *ChanBackupExportRequest) (*ChanBackupSnapshot, error)
 	//
+	//$pld.category: `Backup`
+	//$pld.short_description: `Verify an existing channel backup`
+	//
 	//VerifyChanBackup allows a caller to verify the integrity of a channel backup
 	//snapshot. This method will accept either a packed Single or a packed Multi.
 	//Specifying both will result in an error.
 	VerifyChanBackup(context.Context, *ChanBackupSnapshot) (*VerifyChanBackupResponse, error)
-	// lncli: `restorechanbackup`
+	//
+	//$pld.category: `Backup`
+	//$pld.short_description: `Restore an existing single or multi-channel static channel backup`
+	//
 	//RestoreChannelBackups accepts a set of singular channel backups, or a
 	//single encrypted multi-chan backup and attempts to recover any funds
 	//remaining within the channel. If we are able to unpack the backup, then the
@@ -1623,36 +1901,84 @@ type LightningServer interface {
 	//ups, but the updated set of encrypted multi-chan backups with the closed
 	//channel(s) removed.
 	SubscribeChannelBackups(*ChannelBackupSubscription, Lightning_SubscribeChannelBackupsServer) error
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Scan over the chain to find any transactions which may not have been recorded in the wallet's database
 	ReSync(context.Context, *ReSyncChainRequest) (*ReSyncChainResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Stop a re-synchronization job before it's completion
 	StopReSync(context.Context, *StopReSyncRequest) (*StopReSyncResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Get the wallet seed words for this wallet
 	GetWalletSeed(context.Context, *GetWalletSeedRequest) (*GetWalletSeedResponse, error)
-	//  Change seed's passphrase
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
+	//Change seed's passphrase
 	ChangeSeedPassphrase(context.Context, *ChangeSeedPassphraseRequest) (*ChangeSeedPassphraseResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Get a secret seed which is generated using the wallet's private key, this can be used as a password for another application
 	GetSecret(context.Context, *GetSecretRequest) (*GetSecretResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Imports a WIF-encoded private key to the 'imported' account.
 	ImportPrivKey(context.Context, *ImportPrivKeyRequest) (*ImportPrivKeyResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Returns the private key in WIF encoding that controls some wallet address.
 	DumpPrivKey(context.Context, *DumpPrivKeyRequest) (*DumpPrivKeyResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.
 	ListLockUnspent(context.Context, *ListLockUnspentRequest) (*ListLockUnspentResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Locks or unlocks an unspent output
 	LockUnspent(context.Context, *LockUnspentRequest) (*LockUnspentResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Create a transaction but po not send it to the chain
 	CreateTransaction(context.Context, *CreateTransactionRequest) (*CreateTransactionResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Generates and returns a new payment address
 	GetNewAddress(context.Context, *GetNewAddressRequest) (*GetNewAddressResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Returns a JSON object with details regarding a transaction relevant to this wallet.
 	GetTransaction(context.Context, *GetTransactionRequest) (*GetTransactionResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)
 	SetNetworkStewardVote(context.Context, *SetNetworkStewardVoteRequest) (*SetNetworkStewardVoteResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Find out how the wallet is currently configured to vote in a network steward election
 	GetNetworkStewardVote(context.Context, *GetNetworkStewardVoteRequest) (*GetNetworkStewardVoteResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//Broadcast a transaction
 	BcastTransaction(context.Context, *BcastTransactionRequest) (*BcastTransactionResponse, error)
+	//
+	//$pld.category: ``
+	//$pld.short_description: ``
 	//SendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.
 	SendFrom(context.Context, *SendFromRequest) (*SendFromResponse, error)
 }

--- a/lnd/lnrpc/verrpc.proto.doc.json
+++ b/lnd/lnrpc/verrpc.proto.doc.json
@@ -152,7 +152,7 @@
           "methods": [
             {
               "name": "GetVersion",
-              "description": "pldctl: `version`\nGetVersion returns the current version and build information of the running\ndaemon.",
+              "description": "$pld.category: `Meta`\n$pld.short_description: `Display pldctl and pld version info`\n\nGetVersion returns the current version and build information of the running\ndaemon.",
               "requestType": "VersionRequest",
               "requestLongType": "VersionRequest",
               "requestFullType": "verrpc.VersionRequest",

--- a/lnd/lnrpc/verrpc/verrpc.proto
+++ b/lnd/lnrpc/verrpc/verrpc.proto
@@ -7,7 +7,10 @@ option go_package = "github.com/pkt-cash/pktd/lnd/lnrpc/verrpc";
 // Versioner is a service that can be used to get information about the version
 // and build information of the running daemon.
 service Versioner {
-    /* pldctl: `version`
+    /*
+    $pld.category: `Meta`
+    $pld.short_description: `Display pldctl and pld version info`
+
     GetVersion returns the current version and build information of the running
     daemon.
     */

--- a/lnd/lnrpc/verrpc/verrpc_grpc.pb.go
+++ b/lnd/lnrpc/verrpc/verrpc_grpc.pb.go
@@ -18,7 +18,10 @@ const _ = grpc.SupportPackageIsVersion7
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type VersionerClient interface {
-	// pldctl: `version`
+	//
+	//$pld.category: `Meta`
+	//$pld.short_description: `Display pldctl and pld version info`
+	//
 	//GetVersion returns the current version and build information of the running
 	//daemon.
 	GetVersion(ctx context.Context, in *VersionRequest, opts ...grpc.CallOption) (*Version, error)
@@ -45,7 +48,10 @@ func (c *versionerClient) GetVersion(ctx context.Context, in *VersionRequest, op
 // All implementations should embed UnimplementedVersionerServer
 // for forward compatibility
 type VersionerServer interface {
-	// pldctl: `version`
+	//
+	//$pld.category: `Meta`
+	//$pld.short_description: `Display pldctl and pld version info`
+	//
 	//GetVersion returns the current version and build information of the running
 	//daemon.
 	GetVersion(context.Context, *VersionRequest) (*Version, error)

--- a/lnd/lnrpc/walletkit.proto.doc.json
+++ b/lnd/lnrpc/walletkit.proto.doc.json
@@ -1199,7 +1199,7 @@
           "methods": [
             {
               "name": "ListUnspent",
-              "description": "ListUnspent returns a list of all utxos spendable by the wallet with a\nnumber of confirmations between the specified minimum and maximum.",
+              "description": "$pld.category: `Unspent`\n$pld.short_description: `List utxos available for spending`\n\nListUnspent returns a list of all utxos spendable by the wallet with a\nnumber of confirmations between the specified minimum and maximum.",
               "requestType": "ListUnspentRequest",
               "requestLongType": "ListUnspentRequest",
               "requestFullType": "walletrpc.ListUnspentRequest",

--- a/lnd/lnrpc/walletrpc/walletkit.proto
+++ b/lnd/lnrpc/walletrpc/walletkit.proto
@@ -11,6 +11,9 @@ option go_package = "github.com/pkt-cash/pktd/lnd/lnrpc/walletrpc";
 // daemon's wallet.
 service WalletKit {
     /*
+    $pld.category: `Unspent`
+    $pld.short_description: `List utxos available for spending`
+
     ListUnspent returns a list of all utxos spendable by the wallet with a
     number of confirmations between the specified minimum and maximum.
     */

--- a/lnd/lnrpc/walletrpc/walletkit_grpc.pb.go
+++ b/lnd/lnrpc/walletrpc/walletkit_grpc.pb.go
@@ -20,6 +20,9 @@ const _ = grpc.SupportPackageIsVersion7
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type WalletKitClient interface {
 	//
+	//$pld.category: `Unspent`
+	//$pld.short_description: `List utxos available for spending`
+	//
 	//ListUnspent returns a list of all utxos spendable by the wallet with a
 	//number of confirmations between the specified minimum and maximum.
 	ListUnspent(ctx context.Context, in *ListUnspentRequest, opts ...grpc.CallOption) (*ListUnspentResponse, error)
@@ -293,6 +296,9 @@ func (c *walletKitClient) FinalizePsbt(ctx context.Context, in *FinalizePsbtRequ
 // All implementations should embed UnimplementedWalletKitServer
 // for forward compatibility
 type WalletKitServer interface {
+	//
+	//$pld.category: `Unspent`
+	//$pld.short_description: `List utxos available for spending`
 	//
 	//ListUnspent returns a list of all utxos spendable by the wallet with a
 	//number of confirmations between the specified minimum and maximum.

--- a/lnd/lnrpc/walletunlocker.proto
+++ b/lnd/lnrpc/walletunlocker.proto
@@ -28,6 +28,9 @@ option go_package = "github.com/pkt-cash/pktd/lnd/lnrpc";
 // lnd at first startup, and unlock a previously set up wallet.
 service WalletUnlocker {
     /*
+    $pld.category: `Seed`
+    $pld.short_description: `Create a secret seed`
+
     GenSeed is the first method that should be used to instantiate a new lnd
     instance. This method allows a caller to generate a new aezeed cipher seed
     given an optional passphrase. If provided, the passphrase will be necessary
@@ -40,6 +43,9 @@ service WalletUnlocker {
     rpc GenSeed (GenSeedRequest) returns (GenSeedResponse);
 
     /*
+    $pld.category: `Wallet`
+    $pld.short_description: `Initialize a wallet when starting lnd for the first time`
+
     InitWallet is used when lnd is starting up for the first time to fully
     initialize the daemon and its internal wallet. At the very least a wallet
     password must be provided. This will be used to encrypt sensitive material
@@ -55,7 +61,10 @@ service WalletUnlocker {
     */
     rpc InitWallet (InitWalletRequest) returns (InitWalletResponse);
 
-    /* lncli: `unlock`
+    /*
+    $pld.category: `Wallet`
+    $pld.short_description: `Unlock an encrypted wallet at startup`
+
     UnlockWallet is used at startup of lnd to provide a password to unlock
     the wallet database.
     */

--- a/lnd/lnrpc/walletunlocker.proto.doc.json
+++ b/lnd/lnrpc/walletunlocker.proto.doc.json
@@ -271,7 +271,7 @@
           "methods": [
             {
               "name": "GenSeed",
-              "description": "GenSeed is the first method that should be used to instantiate a new lnd\ninstance. This method allows a caller to generate a new aezeed cipher seed\ngiven an optional passphrase. If provided, the passphrase will be necessary\nto decrypt the cipherseed to expose the internal wallet seed.\n\nOnce the cipherseed is obtained and verified by the user, the InitWallet\nmethod should be used to commit the newly generated seed, and create the\nwallet.",
+              "description": "$pld.category: `Seed`\n$pld.short_description: `Create a secret seed`\n\nGenSeed is the first method that should be used to instantiate a new lnd\ninstance. This method allows a caller to generate a new aezeed cipher seed\ngiven an optional passphrase. If provided, the passphrase will be necessary\nto decrypt the cipherseed to expose the internal wallet seed.\n\nOnce the cipherseed is obtained and verified by the user, the InitWallet\nmethod should be used to commit the newly generated seed, and create the\nwallet.",
               "requestType": "GenSeedRequest",
               "requestLongType": "GenSeedRequest",
               "requestFullType": "lnrpc.GenSeedRequest",
@@ -283,7 +283,7 @@
             },
             {
               "name": "InitWallet",
-              "description": "InitWallet is used when lnd is starting up for the first time to fully\ninitialize the daemon and its internal wallet. At the very least a wallet\npassword must be provided. This will be used to encrypt sensitive material\non disk.\n\nIn the case of a recovery scenario, the user can also specify their aezeed\nmnemonic and passphrase. If set, then the daemon will use this prior state\nto initialize its internal wallet.\n\nAlternatively, this can be used along with the GenSeed RPC to obtain a\nseed, then present it to the user. Once it has been verified by the user,\nthe seed can be fed into this RPC in order to commit the new wallet.",
+              "description": "$pld.category: `Wallet`\n$pld.short_description: `Initialize a wallet when starting lnd for the first time`\n\nInitWallet is used when lnd is starting up for the first time to fully\ninitialize the daemon and its internal wallet. At the very least a wallet\npassword must be provided. This will be used to encrypt sensitive material\non disk.\n\nIn the case of a recovery scenario, the user can also specify their aezeed\nmnemonic and passphrase. If set, then the daemon will use this prior state\nto initialize its internal wallet.\n\nAlternatively, this can be used along with the GenSeed RPC to obtain a\nseed, then present it to the user. Once it has been verified by the user,\nthe seed can be fed into this RPC in order to commit the new wallet.",
               "requestType": "InitWalletRequest",
               "requestLongType": "InitWalletRequest",
               "requestFullType": "lnrpc.InitWalletRequest",
@@ -295,7 +295,7 @@
             },
             {
               "name": "UnlockWallet",
-              "description": "lncli: `unlock`\nUnlockWallet is used at startup of lnd to provide a password to unlock\nthe wallet database.",
+              "description": "$pld.category: `Wallet`\n$pld.short_description: `Unlock an encrypted wallet at startup`\n\nUnlockWallet is used at startup of lnd to provide a password to unlock\nthe wallet database.",
               "requestType": "UnlockWalletRequest",
               "requestLongType": "UnlockWalletRequest",
               "requestFullType": "lnrpc.UnlockWalletRequest",

--- a/lnd/lnrpc/walletunlocker_grpc.pb.go
+++ b/lnd/lnrpc/walletunlocker_grpc.pb.go
@@ -19,6 +19,9 @@ const _ = grpc.SupportPackageIsVersion7
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type WalletUnlockerClient interface {
 	//
+	//$pld.category: `Seed`
+	//$pld.short_description: `Create a secret seed`
+	//
 	//GenSeed is the first method that should be used to instantiate a new lnd
 	//instance. This method allows a caller to generate a new aezeed cipher seed
 	//given an optional passphrase. If provided, the passphrase will be necessary
@@ -28,6 +31,9 @@ type WalletUnlockerClient interface {
 	//method should be used to commit the newly generated seed, and create the
 	//wallet.
 	GenSeed(ctx context.Context, in *GenSeedRequest, opts ...grpc.CallOption) (*GenSeedResponse, error)
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Initialize a wallet when starting lnd for the first time`
 	//
 	//InitWallet is used when lnd is starting up for the first time to fully
 	//initialize the daemon and its internal wallet. At the very least a wallet
@@ -42,7 +48,10 @@ type WalletUnlockerClient interface {
 	//seed, then present it to the user. Once it has been verified by the user,
 	//the seed can be fed into this RPC in order to commit the new wallet.
 	InitWallet(ctx context.Context, in *InitWalletRequest, opts ...grpc.CallOption) (*InitWalletResponse, error)
-	// lncli: `unlock`
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Unlock an encrypted wallet at startup`
+	//
 	//UnlockWallet is used at startup of lnd to provide a password to unlock
 	//the wallet database.
 	UnlockWallet(ctx context.Context, in *UnlockWalletRequest, opts ...grpc.CallOption) (*UnlockWalletResponse, error)
@@ -88,6 +97,9 @@ func (c *walletUnlockerClient) UnlockWallet(ctx context.Context, in *UnlockWalle
 // for forward compatibility
 type WalletUnlockerServer interface {
 	//
+	//$pld.category: `Seed`
+	//$pld.short_description: `Create a secret seed`
+	//
 	//GenSeed is the first method that should be used to instantiate a new lnd
 	//instance. This method allows a caller to generate a new aezeed cipher seed
 	//given an optional passphrase. If provided, the passphrase will be necessary
@@ -97,6 +109,9 @@ type WalletUnlockerServer interface {
 	//method should be used to commit the newly generated seed, and create the
 	//wallet.
 	GenSeed(context.Context, *GenSeedRequest) (*GenSeedResponse, error)
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Initialize a wallet when starting lnd for the first time`
 	//
 	//InitWallet is used when lnd is starting up for the first time to fully
 	//initialize the daemon and its internal wallet. At the very least a wallet
@@ -111,7 +126,10 @@ type WalletUnlockerServer interface {
 	//seed, then present it to the user. Once it has been verified by the user,
 	//the seed can be fed into this RPC in order to commit the new wallet.
 	InitWallet(context.Context, *InitWalletRequest) (*InitWalletResponse, error)
-	// lncli: `unlock`
+	//
+	//$pld.category: `Wallet`
+	//$pld.short_description: `Unlock an encrypted wallet at startup`
+	//
 	//UnlockWallet is used at startup of lnd to provide a password to unlock
 	//the wallet database.
 	UnlockWallet(context.Context, *UnlockWalletRequest) (*UnlockWalletResponse, error)

--- a/lnd/lnrpc/wtclient.proto.doc.json
+++ b/lnd/lnrpc/wtclient.proto.doc.json
@@ -461,7 +461,7 @@
           "methods": [
             {
               "name": "AddTower",
-              "description": "AddTower adds a new watchtower reachable at the given address and\nconsiders it for new sessions. If the watchtower already exists, then\nany new addresses included will be considered when dialing it for\nsession negotiations and backups.",
+              "description": "$pld.category: `Watchtower`\n$pld.short_description: `Register a watchtower to use for future sessions/backups`\n\nAddTower adds a new watchtower reachable at the given address and\nconsiders it for new sessions. If the watchtower already exists, then\nany new addresses included will be considered when dialing it for\nsession negotiations and backups.",
               "requestType": "AddTowerRequest",
               "requestLongType": "AddTowerRequest",
               "requestFullType": "wtclientrpc.AddTowerRequest",
@@ -473,7 +473,7 @@
             },
             {
               "name": "RemoveTower",
-              "description": "RemoveTower removes a watchtower from being considered for future session\nnegotiations and from being used for any subsequent backups until it's added\nagain. If an address is provided, then this RPC only serves as a way of\nremoving the address from the watchtower instead.",
+              "description": "$pld.category: `Watchtower`\n$pld.short_description: `Remove a watchtower to prevent its use for future sessions/backups`\n\nRemoveTower removes a watchtower from being considered for future session\nnegotiations and from being used for any subsequent backups until it's added\nagain. If an address is provided, then this RPC only serves as a way of\nremoving the address from the watchtower instead.",
               "requestType": "RemoveTowerRequest",
               "requestLongType": "RemoveTowerRequest",
               "requestFullType": "wtclientrpc.RemoveTowerRequest",
@@ -485,7 +485,7 @@
             },
             {
               "name": "ListTowers",
-              "description": "ListTowers returns the list of watchtowers registered with the client.",
+              "description": "$pld.category: `Watchtower`\n$pld.short_description: `Display information about all registered watchtowers`\n\nListTowers returns the list of watchtowers registered with the client.",
               "requestType": "ListTowersRequest",
               "requestLongType": "ListTowersRequest",
               "requestFullType": "wtclientrpc.ListTowersRequest",
@@ -497,7 +497,7 @@
             },
             {
               "name": "GetTowerInfo",
-              "description": "GetTowerInfo retrieves information for a registered watchtower.",
+              "description": "$pld.category: `Watchtower`\n$pld.short_description: `Display information about a specific registered watchtower`\n\nGetTowerInfo retrieves information for a registered watchtower.",
               "requestType": "GetTowerInfoRequest",
               "requestLongType": "GetTowerInfoRequest",
               "requestFullType": "wtclientrpc.GetTowerInfoRequest",
@@ -509,7 +509,7 @@
             },
             {
               "name": "Stats",
-              "description": "Stats returns the in-memory statistics of the client since startup.",
+              "description": "$pld.category: `Watchtower`\n$pld.short_description: `Display the session stats of the watchtower client`\n\nStats returns the in-memory statistics of the client since startup.",
               "requestType": "StatsRequest",
               "requestLongType": "StatsRequest",
               "requestFullType": "wtclientrpc.StatsRequest",
@@ -521,7 +521,7 @@
             },
             {
               "name": "Policy",
-              "description": "Policy returns the active watchtower client policy configuration.",
+              "description": "$pld.category: `Watchtower`\n$pld.short_description: `Display the active watchtower client policy configuration`\n\nPolicy returns the active watchtower client policy configuration.",
               "requestType": "PolicyRequest",
               "requestLongType": "PolicyRequest",
               "requestFullType": "wtclientrpc.PolicyRequest",

--- a/lnd/lnrpc/wtclientrpc/wtclient.proto
+++ b/lnd/lnrpc/wtclientrpc/wtclient.proto
@@ -8,6 +8,9 @@ option go_package = "github.com/pkt-cash/pktd/lnd/lnrpc/wtclientrpc";
 // functionality of the daemon.
 service WatchtowerClient {
     /*
+    $pld.category: `Watchtower`
+    $pld.short_description: `Register a watchtower to use for future sessions/backups`
+
     AddTower adds a new watchtower reachable at the given address and
     considers it for new sessions. If the watchtower already exists, then
     any new addresses included will be considered when dialing it for
@@ -16,6 +19,9 @@ service WatchtowerClient {
     rpc AddTower (AddTowerRequest) returns (AddTowerResponse);
 
     /*
+    $pld.category: `Watchtower`
+    $pld.short_description: `Remove a watchtower to prevent its use for future sessions/backups`
+
     RemoveTower removes a watchtower from being considered for future session
     negotiations and from being used for any subsequent backups until it's added
     again. If an address is provided, then this RPC only serves as a way of
@@ -23,16 +29,36 @@ service WatchtowerClient {
     */
     rpc RemoveTower (RemoveTowerRequest) returns (RemoveTowerResponse);
 
-    // ListTowers returns the list of watchtowers registered with the client.
+    /*
+    $pld.category: `Watchtower`
+    $pld.short_description: `Display information about all registered watchtowers`
+
+    ListTowers returns the list of watchtowers registered with the client.
+    */
     rpc ListTowers (ListTowersRequest) returns (ListTowersResponse);
 
-    // GetTowerInfo retrieves information for a registered watchtower.
+    /*
+    $pld.category: `Watchtower`
+    $pld.short_description: `Display information about a specific registered watchtower`
+
+    GetTowerInfo retrieves information for a registered watchtower.
+    */
     rpc GetTowerInfo (GetTowerInfoRequest) returns (Tower);
 
-    // Stats returns the in-memory statistics of the client since startup.
+    /*
+    $pld.category: `Watchtower`
+    $pld.short_description: `Display the session stats of the watchtower client`
+
+    Stats returns the in-memory statistics of the client since startup.
+    */
     rpc Stats (StatsRequest) returns (StatsResponse);
 
-    // Policy returns the active watchtower client policy configuration.
+    /*
+    $pld.category: `Watchtower`
+    $pld.short_description: `Display the active watchtower client policy configuration`
+
+    Policy returns the active watchtower client policy configuration.
+    */
     rpc Policy (PolicyRequest) returns (PolicyResponse);
 }
 

--- a/lnd/lnrpc/wtclientrpc/wtclient_grpc.pb.go
+++ b/lnd/lnrpc/wtclientrpc/wtclient_grpc.pb.go
@@ -19,24 +19,46 @@ const _ = grpc.SupportPackageIsVersion7
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type WatchtowerClientClient interface {
 	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Register a watchtower to use for future sessions/backups`
+	//
 	//AddTower adds a new watchtower reachable at the given address and
 	//considers it for new sessions. If the watchtower already exists, then
 	//any new addresses included will be considered when dialing it for
 	//session negotiations and backups.
 	AddTower(ctx context.Context, in *AddTowerRequest, opts ...grpc.CallOption) (*AddTowerResponse, error)
 	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Remove a watchtower to prevent its use for future sessions/backups`
+	//
 	//RemoveTower removes a watchtower from being considered for future session
 	//negotiations and from being used for any subsequent backups until it's added
 	//again. If an address is provided, then this RPC only serves as a way of
 	//removing the address from the watchtower instead.
 	RemoveTower(ctx context.Context, in *RemoveTowerRequest, opts ...grpc.CallOption) (*RemoveTowerResponse, error)
-	// ListTowers returns the list of watchtowers registered with the client.
+	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Display information about all registered watchtowers`
+	//
+	//ListTowers returns the list of watchtowers registered with the client.
 	ListTowers(ctx context.Context, in *ListTowersRequest, opts ...grpc.CallOption) (*ListTowersResponse, error)
-	// GetTowerInfo retrieves information for a registered watchtower.
+	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Display information about a specific registered watchtower`
+	//
+	//GetTowerInfo retrieves information for a registered watchtower.
 	GetTowerInfo(ctx context.Context, in *GetTowerInfoRequest, opts ...grpc.CallOption) (*Tower, error)
-	// Stats returns the in-memory statistics of the client since startup.
+	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Display the session stats of the watchtower client`
+	//
+	//Stats returns the in-memory statistics of the client since startup.
 	Stats(ctx context.Context, in *StatsRequest, opts ...grpc.CallOption) (*StatsResponse, error)
-	// Policy returns the active watchtower client policy configuration.
+	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Display the active watchtower client policy configuration`
+	//
+	//Policy returns the active watchtower client policy configuration.
 	Policy(ctx context.Context, in *PolicyRequest, opts ...grpc.CallOption) (*PolicyResponse, error)
 }
 
@@ -107,24 +129,46 @@ func (c *watchtowerClientClient) Policy(ctx context.Context, in *PolicyRequest, 
 // for forward compatibility
 type WatchtowerClientServer interface {
 	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Register a watchtower to use for future sessions/backups`
+	//
 	//AddTower adds a new watchtower reachable at the given address and
 	//considers it for new sessions. If the watchtower already exists, then
 	//any new addresses included will be considered when dialing it for
 	//session negotiations and backups.
 	AddTower(context.Context, *AddTowerRequest) (*AddTowerResponse, error)
 	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Remove a watchtower to prevent its use for future sessions/backups`
+	//
 	//RemoveTower removes a watchtower from being considered for future session
 	//negotiations and from being used for any subsequent backups until it's added
 	//again. If an address is provided, then this RPC only serves as a way of
 	//removing the address from the watchtower instead.
 	RemoveTower(context.Context, *RemoveTowerRequest) (*RemoveTowerResponse, error)
-	// ListTowers returns the list of watchtowers registered with the client.
+	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Display information about all registered watchtowers`
+	//
+	//ListTowers returns the list of watchtowers registered with the client.
 	ListTowers(context.Context, *ListTowersRequest) (*ListTowersResponse, error)
-	// GetTowerInfo retrieves information for a registered watchtower.
+	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Display information about a specific registered watchtower`
+	//
+	//GetTowerInfo retrieves information for a registered watchtower.
 	GetTowerInfo(context.Context, *GetTowerInfoRequest) (*Tower, error)
-	// Stats returns the in-memory statistics of the client since startup.
+	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Display the session stats of the watchtower client`
+	//
+	//Stats returns the in-memory statistics of the client since startup.
 	Stats(context.Context, *StatsRequest) (*StatsResponse, error)
-	// Policy returns the active watchtower client policy configuration.
+	//
+	//$pld.category: `Watchtower`
+	//$pld.short_description: `Display the active watchtower client policy configuration`
+	//
+	//Policy returns the active watchtower client policy configuration.
 	Policy(context.Context, *PolicyRequest) (*PolicyResponse, error)
 }
 

--- a/lnd/pkthelp/mkhelp/mkhelp.go
+++ b/lnd/pkthelp/mkhelp/mkhelp.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -142,6 +143,20 @@ func main() {
 			}
 		}
 	}
+
+	var categoryRegexp *regexp.Regexp
+	var shortDescriptionRegexp *regexp.Regexp
+
+	categoryRegexp, err = regexp.Compile("\\$pld\\.category:\\s*`([^`]+)`")
+	if err != nil {
+		panic(err.Error())
+	}
+
+	shortDescriptionRegexp, err = regexp.Compile("\\$pld\\.short_description:\\s*`([^`]+)`")
+	if err != nil {
+		panic(err.Error())
+	}
+
 	for _, t := range templates {
 		for _, f := range t.Files {
 			for _, s := range f.Services {
@@ -151,9 +166,32 @@ func main() {
 					fmt.Printf("        Name: %s,\n", strconv.Quote(m.Name))
 					fmt.Printf("        Service: %s,\n", strconv.Quote(s.Name))
 					if len(s.Description) > 0 {
+
+						var match []string
+						var matchIndex []int
+
+						match = categoryRegexp.FindStringSubmatch(m.Description)
+						if len(match) > 1 {
+							fmt.Printf("        Category: %s,\n", strconv.Quote(match[1]))
+
+							matchIndex = categoryRegexp.FindStringIndex(m.Description)
+							m.Description = m.Description[0:matchIndex[0]] + m.Description[matchIndex[1]:]
+						}
+
+						match = shortDescriptionRegexp.FindStringSubmatch(m.Description)
+						if len(match) > 1 {
+							fmt.Printf("        ShortDescription: %s,\n", strconv.Quote(match[1]))
+
+							matchIndex = shortDescriptionRegexp.FindStringIndex(m.Description)
+							m.Description = m.Description[0:matchIndex[0]] + m.Description[matchIndex[1]:]
+						}
+
 						fmt.Printf("        Description: []string{\n")
 						for _, s := range strings.Split(m.Description, "\n") {
-							fmt.Printf("            %s,\n", strconv.Quote(s))
+							descriptionLine := strings.TrimSpace(s)
+							if len(descriptionLine) > 0 {
+								fmt.Printf("            %s,\n", strconv.Quote(descriptionLine))
+							}
 						}
 						fmt.Printf("        },\n")
 					}

--- a/lnd/pkthelp/pkthelp.go
+++ b/lnd/pkthelp/pkthelp.go
@@ -19,11 +19,13 @@ type Type struct {
 }
 
 type Method struct {
-	Name        string
-	Service     string
-	Description []string
-	Req         Type
-	Res         Type
+	Name             string
+	Service          string
+	Category         string
+	ShortDescription string
+	Description      []string
+	Req              Type
+	Res              Type
 }
 
 var EnumVarientType Type = Type{

--- a/lnd/pkthelp/pkthelp_gen.go
+++ b/lnd/pkthelp/pkthelp_gen.go
@@ -11260,7 +11260,6 @@ func ChainNotifier_RegisterConfirmationsNtfn() Method {
             "RegisterConfirmationsNtfn is a synchronous response-streaming RPC that",
             "registers an intent for a client to be notified once a confirmation request",
             "has reached its required number of confirmations on-chain.",
-            "",
             "A client can specify whether the confirmation request should be for a",
             "particular transaction by its hash or for an output script by specifying a",
             "zero hash.",
@@ -11277,7 +11276,6 @@ func ChainNotifier_RegisterSpendNtfn() Method {
             "RegisterSpendNtfn is a synchronous response-streaming RPC that registers an",
             "intent for a client to be notification once a spend request has been spent",
             "by a transaction that has confirmed on-chain.",
-            "",
             "A client can specify whether the spend request should be for a particular",
             "outpoint  or for an output script by specifying a zero outpoint.",
         },
@@ -11295,7 +11293,6 @@ func ChainNotifier_RegisterBlockEpochNtfn() Method {
             "stream will return a hash and height tuple of a block for each new/stale",
             "block in the chain. It is the client's responsibility to determine whether",
             "the tuple returned is for a new or stale block in the chain.",
-            "",
             "A client can also request a historical backlog of blocks from a particular",
             "point. This allows clients to be idempotent by ensuring that they do not",
             "missing processing a single block within the chain.",
@@ -11358,6 +11355,8 @@ func Router_SendPaymentV2() Method {
     return Method{
         Name: "SendPaymentV2",
         Service: "Router",
+        Category: "Payment",
+        ShortDescription: "Send a payment over lightning",
         Description: []string{
             "SendPaymentV2 attempts to route a payment described by the passed",
             "PaymentRequest to the final destination. The call returns a stream of",
@@ -11371,6 +11370,8 @@ func Router_TrackPaymentV2() Method {
     return Method{
         Name: "TrackPaymentV2",
         Service: "Router",
+        Category: "Payment",
+        ShortDescription: "Track payment",
         Description: []string{
             "TrackPaymentV2 returns an update stream for the payment identified by the",
             "payment hash.",
@@ -11410,6 +11411,8 @@ func Router_SendToRouteV2() Method {
     return Method{
         Name: "SendToRouteV2",
         Service: "Router",
+        Category: "Payment",
+        ShortDescription: "Send a payment over a predefined route",
         Description: []string{
             "SendToRouteV2 attempts to make a payment via the specified route. This",
             "method differs from SendPayment in that it allows users to specify a full",
@@ -11424,6 +11427,8 @@ func Router_ResetMissionControl() Method {
     return Method{
         Name: "ResetMissionControl",
         Service: "Router",
+        Category: "Payment",
+        ShortDescription: "Reset internal mission control state",
         Description: []string{
             "ResetMissionControl clears all mission control state and starts with a clean",
             "slate.",
@@ -11436,6 +11441,8 @@ func Router_QueryMissionControl() Method {
     return Method{
         Name: "QueryMissionControl",
         Service: "Router",
+        Category: "Payment",
+        ShortDescription: "Query the internal mission control state",
         Description: []string{
             "QueryMissionControl exposes the internal mission control state to callers.",
             "It is a development feature.",
@@ -11448,6 +11455,8 @@ func Router_QueryProbability() Method {
     return Method{
         Name: "QueryProbability",
         Service: "Router",
+        Category: "Payment",
+        ShortDescription: "Estimate a success probability",
         Description: []string{
             "QueryProbability returns the current success probability estimate for a",
             "given node pair and amount.",
@@ -11460,6 +11469,8 @@ func Router_BuildRoute() Method {
     return Method{
         Name: "BuildRoute",
         Service: "Router",
+        Category: "Payment",
+        ShortDescription: "Build a route from a list of hop pubkeys",
         Description: []string{
             "BuildRoute builds a fully specified route based on a list of hop public",
             "keys. It retrieves the relevant channel policies from the graph in order to",
@@ -11531,7 +11542,6 @@ func Signer_SignOutputRaw() Method {
             "concerning how the outputs should be signed, which keys they should be",
             "signed with, and also any optional tweaks. The return value is a fixed",
             "64-byte signature (the same format as we use on the wire in Lightning).",
-            "",
             "If we are  unable to sign using the specified keys, then an error will be",
             "returned.",
         },
@@ -11549,7 +11559,6 @@ func Signer_ComputeInputScript() Method {
             "This method should be capable of generating the proper input script for",
             "both regular p2wkh output and p2wkh outputs nested within a regular p2sh",
             "output.",
-            "",
             "Note that when using this method to sign inputs belonging to the wallet,",
             "the only items of the SignDescriptor that need to be populated are pkScript",
             "in the TxOut field, the value in that same field, and finally the input",
@@ -11566,7 +11575,6 @@ func Signer_SignMessage() Method {
         Description: []string{
             "SignMessage signs a message with the key specified in the key locator. The",
             "returned signature is fixed-size LN wire format encoded.",
-            "",
             "The main difference to SignMessage in the main RPC is that a specific key is",
             "used to sign the message instead of the node identity private key.",
         },
@@ -11581,7 +11589,6 @@ func Signer_VerifyMessage() Method {
         Description: []string{
             "VerifyMessage verifies a signature over a message using the public key",
             "provided. The signature must be fixed-size LN wire format encoded.",
-            "",
             "The main difference to VerifyMessage in the main RPC is that the public key",
             "used to sign the message does not have to be a node known to the network.",
         },
@@ -11745,7 +11752,6 @@ func WalletKit_PendingSweeps() Method {
             "attempting to sweep within its central batching engine. Outputs with similar",
             "fee rates are batched together in order to sweep them within a single",
             "transaction.",
-            "",
             "NOTE: Some of the fields within PendingSweepsRequest are not guaranteed to",
             "remain supported. This is an advanced API that depends on the internals of",
             "the UtxoSweeper, so things may change.",
@@ -11767,20 +11773,16 @@ func WalletKit_BumpFee() Method {
             "any point with the addition of new inputs. The list of inputs that",
             "currently exist within lnd's central batching engine can be retrieved",
             "through the PendingSweeps RPC.",
-            "",
             "When bumping the fee of an input that currently exists within lnd's central",
             "batching engine, a higher fee transaction will be created that replaces the",
             "lower fee transaction through the Replace-By-Fee (RBF) policy. If it",
-            "",
             "This RPC also serves useful when wanting to perform a Child-Pays-For-Parent",
             "(CPFP), where the child transaction pays for its parent's fee. This can be",
             "done by specifying an outpoint within the low fee transaction that is under",
             "the control of the wallet.",
-            "",
             "The fee preference can be expressed either as a specific fee rate or a delta",
             "of blocks in which the output should be swept on-chain within. If a fee",
             "preference is not explicitly specified, then an error is returned.",
-            "",
             "Note that this RPC currently doesn't perform any validation checks on the",
             "fee preference being provided. For now, the responsibility of ensuring that",
             "the new fee preference is sufficient is delegated to the user.",
@@ -11825,16 +11827,13 @@ func WalletKit_FundPsbt() Method {
             "the outputs specified in the template. There are two ways of specifying a",
             "template: Either by passing in a PSBT with at least one output declared or",
             "by passing in a raw TxTemplate message.",
-            "",
             "If there are no inputs specified in the template, coin selection is",
             "performed automatically. If the template does contain any inputs, it is",
             "assumed that full coin selection happened externally and no additional",
             "inputs are added. If the specified inputs aren't enough to fund the outputs",
             "with the given fee rate, an error is returned.",
-            "",
             "After either selecting or verifying the inputs, all input UTXOs are locked",
             "with an internal app ID.",
-            "",
             "NOTE: If this method returns without an error, it is the caller's",
             "responsibility to either spend the locked UTXOs (by finalizing and then",
             "publishing the transaction) or to unlock/release the locked UTXOs in case of",
@@ -11856,7 +11855,6 @@ func WalletKit_FinalizePsbt() Method {
             "without witness data that do not belong to lnd's wallet, this method will",
             "fail. If no error is returned, the PSBT is ready to be extracted and the",
             "final TX within to be broadcast.",
-            "",
             "NOTE: This method does NOT publish the transaction once finalized. It is the",
             "caller's responsibility to either publish the transaction on success or",
             "unlock/release any locked UTXOs in case of an error in this method.",
@@ -11960,7 +11958,6 @@ func WalletUnlocker_GenSeed() Method {
             "instance. This method allows a caller to generate a new aezeed cipher seed",
             "given an optional passphrase. If provided, the passphrase will be necessary",
             "to decrypt the cipherseed to expose the internal wallet seed.",
-            "",
             "Once the cipherseed is obtained and verified by the user, the InitWallet",
             "method should be used to commit the newly generated seed, and create the",
             "wallet.",
@@ -11978,11 +11975,9 @@ func WalletUnlocker_InitWallet() Method {
             "initialize the daemon and its internal wallet. At the very least a wallet",
             "password must be provided. This will be used to encrypt sensitive material",
             "on disk.",
-            "",
             "In the case of a recovery scenario, the user can also specify their aezeed",
             "mnemonic and passphrase. If set, then the daemon will use this prior state",
             "to initialize its internal wallet.",
-            "",
             "Alternatively, this can be used along with the GenSeed RPC to obtain a",
             "seed, then present it to the user. Once it has been verified by the user,",
             "the seed can be fed into this RPC in order to commit the new wallet.",
@@ -12040,8 +12035,9 @@ func Lightning_WalletBalance() Method {
     return Method{
         Name: "WalletBalance",
         Service: "Lightning",
+        Category: "Wallet",
+        ShortDescription: "Compute and display the wallet's current balance",
         Description: []string{
-            "lncli: `walletbalance`",
             "WalletBalance returns total unspent outputs(confirmed and unconfirmed), all",
             "confirmed unspent outputs and all unconfirmed unspent outputs under control",
             "of the wallet.",
@@ -12054,8 +12050,9 @@ func Lightning_GetAddressBalances() Method {
     return Method{
         Name: "GetAddressBalances",
         Service: "Lightning",
+        Category: "Wallet",
         Description: []string{
-            "lncli: `getaddressbalances`",
+            "$pld.short_description: ``",
             "GetAddressBalances returns the balance for each of the addresses in the wallet.",
         },
         Req: mklnrpc_GetAddressBalancesRequest(),
@@ -12066,8 +12063,9 @@ func Lightning_ChannelBalance() Method {
     return Method{
         Name: "ChannelBalance",
         Service: "Lightning",
+        Category: "Channel",
+        ShortDescription: "Returns the sum of the total available channel balance across all open channels",
         Description: []string{
-            "lncli: `channelbalance`",
             "ChannelBalance returns a report on the total funds across all open channels,",
             "categorized in local/remote, pending local/remote and unsettled local/remote",
             "balances.",
@@ -12082,6 +12080,8 @@ func Lightning_GetTransactions() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `listchaintxns`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "GetTransactions returns a list describing all the known transactions",
             "relevant to the wallet.",
         },
@@ -12095,9 +12095,10 @@ func Lightning_EstimateFee() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `estimatefee`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "EstimateFee asks the chain backend to estimate the fee rate and total fees",
             "for a transaction that pays to multiple specified outputs.",
-            "",
             "When using REST, the `AddrToAmount` map type can be set by appending",
             "`&AddrToAmount[<address>]=<amount_to_send>` to the URL. Unfortunately this",
             "map type doesn't appear in the REST API documentation because of a bug in",
@@ -12113,6 +12114,8 @@ func Lightning_SendCoins() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `sendcoins`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "SendCoins executes a request to send coins to a particular address. Unlike",
             "SendMany, this RPC call only allows creating a single output at a time. If",
             "neither target_conf, or sat_per_byte are set, then the internal wallet will",
@@ -12129,8 +12132,9 @@ func Lightning_ListUnspent() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `listunspent`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Deprecated, use walletrpc.ListUnspent instead.",
-            "",
             "ListUnspent returns a list of all utxos spendable by the wallet with a",
             "number of confirmations between the specified minimum and maximum.",
         },
@@ -12143,6 +12147,8 @@ func Lightning_SubscribeTransactions() Method {
         Name: "SubscribeTransactions",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "SubscribeTransactions creates a uni-directional stream from the server to",
             "the client in which any newly discovered transactions relevant to the",
             "wallet are sent over.",
@@ -12157,6 +12163,8 @@ func Lightning_SendMany() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `sendmany`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "SendMany handles a request for a transaction that creates multiple specified",
             "outputs in parallel. If neither target_conf, or sat_per_byte are set, then",
             "the internal wallet will consult its fee model to determine a fee for the",
@@ -12172,6 +12180,8 @@ func Lightning_NewAddress() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `newaddress`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "NewAddress creates a new address under control of the local wallet.",
         },
         Req: mklnrpc_NewAddressRequest(),
@@ -12184,6 +12194,8 @@ func Lightning_SignMessage() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `signmessage`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "SignMessage signs a message with this node's private key. The returned",
             "signature string is `zbase32` encoded and pubkey recoverable, meaning that",
             "only the message digest and signature are needed for verification.",
@@ -12198,6 +12210,8 @@ func Lightning_ConnectPeer() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `connect`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "ConnectPeer attempts to establish a connection to a remote peer. This is at",
             "the networking level, and is used for communication between nodes. This is",
             "distinct from establishing a channel with a peer.",
@@ -12212,6 +12226,8 @@ func Lightning_DisconnectPeer() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `disconnect`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "DisconnectPeer attempts to disconnect one peer from another identified by a",
             "given pubKey. In the case that we currently have a pending or active channel",
             "with the target peer, then this action will be not be allowed.",
@@ -12226,6 +12242,8 @@ func Lightning_ListPeers() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `listpeers`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "ListPeers returns a verbose listing of all currently active peers.",
         },
         Req: mklnrpc_ListPeersRequest(),
@@ -12237,6 +12255,8 @@ func Lightning_SubscribePeerEvents() Method {
         Name: "SubscribePeerEvents",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "SubscribePeerEvents creates a uni-directional stream from the server to",
             "the client in which any events relevant to the state of peers are sent",
             "over. Events include peers going online and offline.",
@@ -12251,6 +12271,8 @@ func Lightning_GetInfo() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `getinfo`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "GetInfo returns general information concerning the lightning node including",
             "it's identity pubkey, alias, the chains it is connected to, and information",
             "concerning the number of open+pending channels.",
@@ -12265,6 +12287,8 @@ func Lightning_GetRecoveryInfo() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `getrecoveryinfo`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "GetRecoveryInfo returns information concerning the recovery mode including",
             "whether it's in a recovery mode, whether the recovery is finished, and the",
             "progress made so far.",
@@ -12277,8 +12301,9 @@ func Lightning_PendingChannels() Method {
     return Method{
         Name: "PendingChannels",
         Service: "Lightning",
+        Category: "Channel",
+        ShortDescription: "Display information pertaining to pending channels",
         Description: []string{
-            "lncli: `pendingchannels`",
             "PendingChannels returns a list of all the channels that are currently",
             "considered \"pending\". A channel is pending if it has finished the funding",
             "workflow and is waiting for confirmations for the funding txn, or is in the",
@@ -12292,8 +12317,9 @@ func Lightning_ListChannels() Method {
     return Method{
         Name: "ListChannels",
         Service: "Lightning",
+        Category: "Channel",
+        ShortDescription: "List all open channels",
         Description: []string{
-            "lncli: `listchannels`",
             "ListChannels returns a description of all the open channels that this node",
             "is a participant in.",
         },
@@ -12319,8 +12345,9 @@ func Lightning_ClosedChannels() Method {
     return Method{
         Name: "ClosedChannels",
         Service: "Lightning",
+        Category: "Channel",
+        ShortDescription: "List all closed channels",
         Description: []string{
-            "lncli: `closedchannels`",
             "ClosedChannels returns a description of all the closed channels that",
             "this node was a participant in.",
         },
@@ -12346,8 +12373,9 @@ func Lightning_OpenChannel() Method {
     return Method{
         Name: "OpenChannel",
         Service: "Lightning",
+        Category: "Channel",
+        ShortDescription: "Open a channel to a node or an existing peer",
         Description: []string{
-            "lncli: `openchannel`",
             "OpenChannel attempts to open a singly funded channel specified in the",
             "request to a remote peer. Users are able to specify a target number of",
             "blocks that the funding transaction should be confirmed in, or a manual fee",
@@ -12366,6 +12394,8 @@ func Lightning_FundingStateStep() Method {
         Name: "FundingStateStep",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "FundingStateStep is an advanced funding related call that allows the caller",
             "to either execute some preparatory steps for a funding workflow, or",
             "manually progress a funding workflow. The primary way a funding flow is",
@@ -12384,6 +12414,8 @@ func Lightning_ChannelAcceptor() Method {
         Name: "ChannelAcceptor",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "ChannelAcceptor dispatches a bi-directional streaming RPC in which",
             "OpenChannel requests are sent to the client and the client responds with",
             "a boolean that tells LND whether or not to accept the channel. This allows",
@@ -12398,8 +12430,9 @@ func Lightning_CloseChannel() Method {
     return Method{
         Name: "CloseChannel",
         Service: "Lightning",
+        Category: "Channel",
+        ShortDescription: "Close an existing channel",
         Description: []string{
-            "lncli: `closechannel`",
             "CloseChannel attempts to close an active channel identified by its channel",
             "outpoint (ChannelPoint). The actions of this method can additionally be",
             "augmented to attempt a force close after a timeout period in the case of an",
@@ -12416,8 +12449,9 @@ func Lightning_AbandonChannel() Method {
     return Method{
         Name: "AbandonChannel",
         Service: "Lightning",
+        Category: "Channel",
+        ShortDescription: "Abandons an existing channel",
         Description: []string{
-            "lncli: `abandonchannel`",
             "AbandonChannel removes all channel state from the database except for a",
             "close summary. This method can be used to get rid of permanently unusable",
             "channels due to bugs fixed in newer versions of lnd. This method can also be",
@@ -12434,7 +12468,6 @@ func Lightning_SendPayment() Method {
         Name: "SendPayment",
         Service: "Lightning",
         Description: []string{
-            "lncli: `sendpayment`",
             "Deprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a",
             "bi-directional streaming RPC for sending payments through the Lightning",
             "Network. A single RPC invocation creates a persistent bi-directional",
@@ -12491,8 +12524,9 @@ func Lightning_AddInvoice() Method {
     return Method{
         Name: "AddInvoice",
         Service: "Lightning",
+        Category: "Invoice",
+        ShortDescription: "Add a new invoice",
         Description: []string{
-            "lncli: `addinvoice`",
             "AddInvoice attempts to add a new invoice to the invoice database. Any",
             "duplicated invoices are rejected, therefore all invoices *must* have a",
             "unique payment preimage.",
@@ -12505,8 +12539,9 @@ func Lightning_ListInvoices() Method {
     return Method{
         Name: "ListInvoices",
         Service: "Lightning",
+        Category: "Invoice",
+        ShortDescription: "List all invoices currently stored within the database. Any active debug invoices are ignored",
         Description: []string{
-            "lncli: `listinvoices`",
             "ListInvoices returns a list of all the invoices currently stored within the",
             "database. Any active debug invoices are ignored. It has full support for",
             "paginated responses, allowing users to query for specific invoices through",
@@ -12523,8 +12558,9 @@ func Lightning_LookupInvoice() Method {
     return Method{
         Name: "LookupInvoice",
         Service: "Lightning",
+        Category: "Invoice",
+        ShortDescription: "Lookup an existing invoice by its payment hash",
         Description: []string{
-            "lncli: `lookupinvoice`",
             "LookupInvoice attempts to look up an invoice according to its payment hash.",
             "The passed payment hash *must* be exactly 32 bytes, if not, an error is",
             "returned.",
@@ -12538,6 +12574,8 @@ func Lightning_SubscribeInvoices() Method {
         Name: "SubscribeInvoices",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "SubscribeInvoices returns a uni-directional stream (server -> client) for",
             "notifying the client of newly added/settled invoices. The caller can",
             "optionally specify the add_index and/or the settle_index. If the add_index",
@@ -12556,8 +12594,9 @@ func Lightning_DecodePayReq() Method {
     return Method{
         Name: "DecodePayReq",
         Service: "Lightning",
+        Category: "Invoice",
+        ShortDescription: "Decode a payment request",
         Description: []string{
-            "lncli: `decodepayreq`",
             "DecodePayReq takes an encoded payment request string and attempts to decode",
             "it, returning a full description of the conditions encoded within the",
             "payment request.",
@@ -12570,8 +12609,9 @@ func Lightning_ListPayments() Method {
     return Method{
         Name: "ListPayments",
         Service: "Lightning",
+        Category: "Payment",
+        ShortDescription: "List all outgoing payments",
         Description: []string{
-            "lncli: `listpayments`",
             "ListPayments returns a list of all outgoing payments.",
         },
         Req: mklnrpc_ListPaymentsRequest(),
@@ -12593,8 +12633,9 @@ func Lightning_DescribeGraph() Method {
     return Method{
         Name: "DescribeGraph",
         Service: "Lightning",
+        Category: "Graph",
+        ShortDescription: "Describe the network graph",
         Description: []string{
-            "lncli: `describegraph`",
             "DescribeGraph returns a description of the latest graph state from the",
             "point of view of the node. The graph information is partitioned into two",
             "components: all the nodes/vertexes, and all the edges that connect the",
@@ -12610,8 +12651,9 @@ func Lightning_GetNodeMetrics() Method {
     return Method{
         Name: "GetNodeMetrics",
         Service: "Lightning",
+        Category: "Graph",
+        ShortDescription: "Get node metrics",
         Description: []string{
-            "lncli: `getnodemetrics`",
             "GetNodeMetrics returns node metrics calculated from the graph. Currently",
             "the only supported metric is betweenness centrality of individual nodes.",
         },
@@ -12623,8 +12665,9 @@ func Lightning_GetChanInfo() Method {
     return Method{
         Name: "GetChanInfo",
         Service: "Lightning",
+        Category: "Graph",
+        ShortDescription: "Get the state of a channel",
         Description: []string{
-            "lncli: `getchaninfo`",
             "GetChanInfo returns the latest authenticated network announcement for the",
             "given channel identified by its channel ID: an 8-byte integer which",
             "uniquely identifies the location of transaction's funding output within the",
@@ -12638,8 +12681,9 @@ func Lightning_GetNodeInfo() Method {
     return Method{
         Name: "GetNodeInfo",
         Service: "Lightning",
+        Category: "Graph",
+        ShortDescription: "Get information on a specific node",
         Description: []string{
-            "lncli: `getnodeinfo`",
             "GetNodeInfo returns the latest advertised, aggregated, and authenticated",
             "channel information for the specified node identified by its public key.",
         },
@@ -12651,14 +12695,14 @@ func Lightning_QueryRoutes() Method {
     return Method{
         Name: "QueryRoutes",
         Service: "Lightning",
+        Category: "Payment",
+        ShortDescription: "Query a route to a destination",
         Description: []string{
-            "lncli: `queryroutes`",
             "QueryRoutes attempts to query the daemon's Channel Router for a possible",
             "route to a target destination capable of carrying a specific amount of",
             "satoshis. The returned route contains the full details required to craft and",
             "send an HTLC, also including the necessary information that should be",
             "present within the Sphinx packet encapsulated within the HTLC.",
-            "",
             "When using REST, the `dest_custom_records` map type can be set by appending",
             "`&dest_custom_records[<record_number>]=<record_data_base64_url_encoded>`",
             "to the URL. Unfortunately this map type doesn't appear in the REST API",
@@ -12672,8 +12716,9 @@ func Lightning_GetNetworkInfo() Method {
     return Method{
         Name: "GetNetworkInfo",
         Service: "Lightning",
+        Category: "Channel",
+        ShortDescription: "Get statistical information about the current state of the network",
         Description: []string{
-            "lncli: `getnetworkinfo`",
             "GetNetworkInfo returns some basic stats about the known channel graph from",
             "the point of view of the node.",
         },
@@ -12687,6 +12732,8 @@ func Lightning_StopDaemon() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `stop`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "StopDaemon will send a shutdown request to the interrupt handler, triggering",
             "a graceful shutdown of the daemon.",
         },
@@ -12716,6 +12763,8 @@ func Lightning_DebugLevel() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `debuglevel`",
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "DebugLevel allows a caller to programmatically set the logging verbosity of",
             "lnd. The logging can be targeted according to a coarse daemon-wide logging",
             "level, or in a granular fashion to specify the logging for a target",
@@ -12729,8 +12778,9 @@ func Lightning_FeeReport() Method {
     return Method{
         Name: "FeeReport",
         Service: "Lightning",
+        Category: "Channel",
+        ShortDescription: "Display the current fee policies of all active channels",
         Description: []string{
-            "lncli: `feereport`",
             "FeeReport allows the caller to obtain a report detailing the current fee",
             "schedule enforced by the node globally for each channel.",
         },
@@ -12742,8 +12792,9 @@ func Lightning_UpdateChannelPolicy() Method {
     return Method{
         Name: "UpdateChannelPolicy",
         Service: "Lightning",
+        Category: "Channel",
+        ShortDescription: "Update the channel policy for all channels, or a single channel",
         Description: []string{
-            "lncli: `updatechanpolicy`",
             "UpdateChannelPolicy allows the caller to update the fee schedule and",
             "channel policies for all channels globally, or a particular channel.",
         },
@@ -12755,13 +12806,13 @@ func Lightning_ForwardingHistory() Method {
     return Method{
         Name: "ForwardingHistory",
         Service: "Lightning",
+        Category: "Payment",
+        ShortDescription: "Query the history of all forwarded HTLCs",
         Description: []string{
-            "lncli: `fwdinghistory`",
             "ForwardingHistory allows the caller to query the htlcswitch for a record of",
             "all HTLCs forwarded within the target time range, and integer offset",
             "within that time range. If no time-range is specified, then the first chunk",
             "of the past 24 hrs of forwarding history are returned.",
-            "",
             "A list of forwarding events are returned. The size of each forwarding event",
             "is 40 bytes, and the max message size able to be returned in gRPC is 4 MiB.",
             "As a result each message can only contain 50k entries. Each response has",
@@ -12776,8 +12827,9 @@ func Lightning_ExportChannelBackup() Method {
     return Method{
         Name: "ExportChannelBackup",
         Service: "Lightning",
+        Category: "Backup",
+        ShortDescription: "Obtain a static channel back up for a selected channels, or all known channels",
         Description: []string{
-            "lncli: `exportchanbackup`",
             "ExportChannelBackup attempts to return an encrypted static channel backup",
             "for the target channel identified by it channel point. The backup is",
             "encrypted with a key generated from the aezeed seed of the user. The",
@@ -12808,6 +12860,8 @@ func Lightning_VerifyChanBackup() Method {
     return Method{
         Name: "VerifyChanBackup",
         Service: "Lightning",
+        Category: "Backup",
+        ShortDescription: "Verify an existing channel backup",
         Description: []string{
             "VerifyChanBackup allows a caller to verify the integrity of a channel backup",
             "snapshot. This method will accept either a packed Single or a packed Multi.",
@@ -12821,8 +12875,9 @@ func Lightning_RestoreChannelBackups() Method {
     return Method{
         Name: "RestoreChannelBackups",
         Service: "Lightning",
+        Category: "Backup",
+        ShortDescription: "Restore an existing single or multi-channel static channel backup",
         Description: []string{
-            "lncli: `restorechanbackup`",
             "RestoreChannelBackups accepts a set of singular channel backups, or a",
             "single encrypted multi-chan backup and attempts to recover any funds",
             "remaining within the channel. If we are able to unpack the backup, then the",
@@ -12854,6 +12909,8 @@ func Lightning_ReSync() Method {
         Name: "ReSync",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Scan over the chain to find any transactions which may not have been recorded in the wallet's database",
         },
         Req: mklnrpc_ReSyncChainRequest(),
@@ -12865,6 +12922,8 @@ func Lightning_StopReSync() Method {
         Name: "StopReSync",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Stop a re-synchronization job before it's completion",
         },
         Req: mklnrpc_StopReSyncRequest(),
@@ -12876,6 +12935,8 @@ func Lightning_GetWalletSeed() Method {
         Name: "GetWalletSeed",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Get the wallet seed words for this wallet",
         },
         Req: mklnrpc_GetWalletSeedRequest(),
@@ -12887,6 +12948,8 @@ func Lightning_ChangeSeedPassphrase() Method {
         Name: "ChangeSeedPassphrase",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Change seed's passphrase",
         },
         Req: mklnrpc_ChangeSeedPassphraseRequest(),
@@ -12898,6 +12961,8 @@ func Lightning_GetSecret() Method {
         Name: "GetSecret",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Get a secret seed which is generated using the wallet's private key, this can be used as a password for another application",
         },
         Req: mklnrpc_GetSecretRequest(),
@@ -12909,6 +12974,8 @@ func Lightning_ImportPrivKey() Method {
         Name: "ImportPrivKey",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Imports a WIF-encoded private key to the 'imported' account.",
         },
         Req: mklnrpc_ImportPrivKeyRequest(),
@@ -12920,6 +12987,8 @@ func Lightning_DumpPrivKey() Method {
         Name: "DumpPrivKey",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Returns the private key in WIF encoding that controls some wallet address.",
         },
         Req: mklnrpc_DumpPrivKeyRequest(),
@@ -12931,6 +13000,8 @@ func Lightning_ListLockUnspent() Method {
         Name: "ListLockUnspent",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.",
         },
         Req: mklnrpc_ListLockUnspentRequest(),
@@ -12942,6 +13013,8 @@ func Lightning_LockUnspent() Method {
         Name: "LockUnspent",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Locks or unlocks an unspent output",
         },
         Req: mklnrpc_LockUnspentRequest(),
@@ -12953,6 +13026,8 @@ func Lightning_CreateTransaction() Method {
         Name: "CreateTransaction",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Create a transaction but po not send it to the chain",
         },
         Req: mklnrpc_CreateTransactionRequest(),
@@ -12964,6 +13039,8 @@ func Lightning_GetNewAddress() Method {
         Name: "GetNewAddress",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Generates and returns a new payment address",
         },
         Req: mklnrpc_GetNewAddressRequest(),
@@ -12975,6 +13052,8 @@ func Lightning_GetTransaction() Method {
         Name: "GetTransaction",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Returns a JSON object with details regarding a transaction relevant to this wallet.",
         },
         Req: mklnrpc_GetTransactionRequest(),
@@ -12986,6 +13065,8 @@ func Lightning_SetNetworkStewardVote() Method {
         Name: "SetNetworkStewardVote",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)",
         },
         Req: mklnrpc_SetNetworkStewardVoteRequest(),
@@ -12997,6 +13078,8 @@ func Lightning_GetNetworkStewardVote() Method {
         Name: "GetNetworkStewardVote",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Find out how the wallet is currently configured to vote in a network steward election",
         },
         Req: mklnrpc_GetNetworkStewardVoteRequest(),
@@ -13008,6 +13091,8 @@ func Lightning_BcastTransaction() Method {
         Name: "BcastTransaction",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "Broadcast a transaction",
         },
         Req: mklnrpc_BcastTransactionRequest(),
@@ -13019,6 +13104,8 @@ func Lightning_SendFrom() Method {
         Name: "SendFrom",
         Service: "Lightning",
         Description: []string{
+            "$pld.category: ``",
+            "$pld.short_description: ``",
             "SendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.",
         },
         Req: mklnrpc_SendFromRequest(),

--- a/lnd/pkthelp/pkthelp_gen.go
+++ b/lnd/pkthelp/pkthelp_gen.go
@@ -11618,8 +11618,9 @@ func Versioner_GetVersion() Method {
     return Method{
         Name: "GetVersion",
         Service: "Versioner",
+        Category: "Meta",
+        ShortDescription: "Display pldctl and pld version info",
         Description: []string{
-            "pldctl: `version`",
             "GetVersion returns the current version and build information of the running",
             "daemon.",
         },
@@ -11631,6 +11632,8 @@ func WalletKit_ListUnspent() Method {
     return Method{
         Name: "ListUnspent",
         Service: "WalletKit",
+        Category: "Unspent",
+        ShortDescription: "List utxos available for spending",
         Description: []string{
             "ListUnspent returns a list of all utxos spendable by the wallet with a",
             "number of confirmations between the specified minimum and maximum.",
@@ -11881,6 +11884,8 @@ func WatchtowerClient_AddTower() Method {
     return Method{
         Name: "AddTower",
         Service: "WatchtowerClient",
+        Category: "Watchtower",
+        ShortDescription: "Register a watchtower to use for future sessions/backups",
         Description: []string{
             "AddTower adds a new watchtower reachable at the given address and",
             "considers it for new sessions. If the watchtower already exists, then",
@@ -11895,6 +11900,8 @@ func WatchtowerClient_RemoveTower() Method {
     return Method{
         Name: "RemoveTower",
         Service: "WatchtowerClient",
+        Category: "Watchtower",
+        ShortDescription: "Remove a watchtower to prevent its use for future sessions/backups",
         Description: []string{
             "RemoveTower removes a watchtower from being considered for future session",
             "negotiations and from being used for any subsequent backups until it's added",
@@ -11909,6 +11916,8 @@ func WatchtowerClient_ListTowers() Method {
     return Method{
         Name: "ListTowers",
         Service: "WatchtowerClient",
+        Category: "Watchtower",
+        ShortDescription: "Display information about all registered watchtowers",
         Description: []string{
             "ListTowers returns the list of watchtowers registered with the client.",
         },
@@ -11920,6 +11929,8 @@ func WatchtowerClient_GetTowerInfo() Method {
     return Method{
         Name: "GetTowerInfo",
         Service: "WatchtowerClient",
+        Category: "Watchtower",
+        ShortDescription: "Display information about a specific registered watchtower",
         Description: []string{
             "GetTowerInfo retrieves information for a registered watchtower.",
         },
@@ -11931,6 +11942,8 @@ func WatchtowerClient_Stats() Method {
     return Method{
         Name: "Stats",
         Service: "WatchtowerClient",
+        Category: "Watchtower",
+        ShortDescription: "Display the session stats of the watchtower client",
         Description: []string{
             "Stats returns the in-memory statistics of the client since startup.",
         },
@@ -11942,6 +11955,8 @@ func WatchtowerClient_Policy() Method {
     return Method{
         Name: "Policy",
         Service: "WatchtowerClient",
+        Category: "Watchtower",
+        ShortDescription: "Display the active watchtower client policy configuration",
         Description: []string{
             "Policy returns the active watchtower client policy configuration.",
         },
@@ -11953,6 +11968,8 @@ func WalletUnlocker_GenSeed() Method {
     return Method{
         Name: "GenSeed",
         Service: "WalletUnlocker",
+        Category: "Seed",
+        ShortDescription: "Create a secret seed",
         Description: []string{
             "GenSeed is the first method that should be used to instantiate a new lnd",
             "instance. This method allows a caller to generate a new aezeed cipher seed",
@@ -11970,6 +11987,8 @@ func WalletUnlocker_InitWallet() Method {
     return Method{
         Name: "InitWallet",
         Service: "WalletUnlocker",
+        Category: "Wallet",
+        ShortDescription: "Initialize a wallet when starting lnd for the first time",
         Description: []string{
             "InitWallet is used when lnd is starting up for the first time to fully",
             "initialize the daemon and its internal wallet. At the very least a wallet",
@@ -11990,8 +12009,9 @@ func WalletUnlocker_UnlockWallet() Method {
     return Method{
         Name: "UnlockWallet",
         Service: "WalletUnlocker",
+        Category: "Wallet",
+        ShortDescription: "Unlock an encrypted wallet at startup",
         Description: []string{
-            "lncli: `unlock`",
             "UnlockWallet is used at startup of lnd to provide a password to unlock",
             "the wallet database.",
         },
@@ -12050,9 +12070,9 @@ func Lightning_GetAddressBalances() Method {
     return Method{
         Name: "GetAddressBalances",
         Service: "Lightning",
-        Category: "Wallet",
+        Category: "Address",
+        ShortDescription: "Compute and display balances for each address in the wallet",
         Description: []string{
-            "$pld.short_description: ``",
             "GetAddressBalances returns the balance for each of the addresses in the wallet.",
         },
         Req: mklnrpc_GetAddressBalancesRequest(),
@@ -12078,10 +12098,9 @@ func Lightning_GetTransactions() Method {
     return Method{
         Name: "GetTransactions",
         Service: "Lightning",
+        Category: "Transaction",
+        ShortDescription: "List transactions from the wallet",
         Description: []string{
-            "lncli: `listchaintxns`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "GetTransactions returns a list describing all the known transactions",
             "relevant to the wallet.",
         },
@@ -12093,10 +12112,9 @@ func Lightning_EstimateFee() Method {
     return Method{
         Name: "EstimateFee",
         Service: "Lightning",
+        Category: "Neutrino",
+        ShortDescription: "Get fee estimates for sending bitcoin on-chain to multiple addresses",
         Description: []string{
-            "lncli: `estimatefee`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "EstimateFee asks the chain backend to estimate the fee rate and total fees",
             "for a transaction that pays to multiple specified outputs.",
             "When using REST, the `AddrToAmount` map type can be set by appending",
@@ -12112,10 +12130,9 @@ func Lightning_SendCoins() Method {
     return Method{
         Name: "SendCoins",
         Service: "Lightning",
+        Category: "Transaction",
+        ShortDescription: "Send bitcoin on-chain to an address",
         Description: []string{
-            "lncli: `sendcoins`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "SendCoins executes a request to send coins to a particular address. Unlike",
             "SendMany, this RPC call only allows creating a single output at a time. If",
             "neither target_conf, or sat_per_byte are set, then the internal wallet will",
@@ -12132,8 +12149,6 @@ func Lightning_ListUnspent() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `listunspent`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Deprecated, use walletrpc.ListUnspent instead.",
             "ListUnspent returns a list of all utxos spendable by the wallet with a",
             "number of confirmations between the specified minimum and maximum.",
@@ -12147,8 +12162,6 @@ func Lightning_SubscribeTransactions() Method {
         Name: "SubscribeTransactions",
         Service: "Lightning",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "SubscribeTransactions creates a uni-directional stream from the server to",
             "the client in which any newly discovered transactions relevant to the",
             "wallet are sent over.",
@@ -12161,10 +12174,9 @@ func Lightning_SendMany() Method {
     return Method{
         Name: "SendMany",
         Service: "Lightning",
+        Category: "Transaction",
+        ShortDescription: "Send bitcoin on-chain to multiple addresses",
         Description: []string{
-            "lncli: `sendmany`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "SendMany handles a request for a transaction that creates multiple specified",
             "outputs in parallel. If neither target_conf, or sat_per_byte are set, then",
             "the internal wallet will consult its fee model to determine a fee for the",
@@ -12179,9 +12191,6 @@ func Lightning_NewAddress() Method {
         Name: "NewAddress",
         Service: "Lightning",
         Description: []string{
-            "lncli: `newaddress`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "NewAddress creates a new address under control of the local wallet.",
         },
         Req: mklnrpc_NewAddressRequest(),
@@ -12192,10 +12201,9 @@ func Lightning_SignMessage() Method {
     return Method{
         Name: "SignMessage",
         Service: "Lightning",
+        Category: "Address",
+        ShortDescription: "Signs a message using the private key of a payment address",
         Description: []string{
-            "lncli: `signmessage`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "SignMessage signs a message with this node's private key. The returned",
             "signature string is `zbase32` encoded and pubkey recoverable, meaning that",
             "only the message digest and signature are needed for verification.",
@@ -12208,10 +12216,9 @@ func Lightning_ConnectPeer() Method {
     return Method{
         Name: "ConnectPeer",
         Service: "Lightning",
+        Category: "Peer",
+        ShortDescription: "Connect to a remote pld peer",
         Description: []string{
-            "lncli: `connect`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "ConnectPeer attempts to establish a connection to a remote peer. This is at",
             "the networking level, and is used for communication between nodes. This is",
             "distinct from establishing a channel with a peer.",
@@ -12224,10 +12231,9 @@ func Lightning_DisconnectPeer() Method {
     return Method{
         Name: "DisconnectPeer",
         Service: "Lightning",
+        Category: "Peer",
+        ShortDescription: "Disconnect a remote pld peer identified by public key",
         Description: []string{
-            "lncli: `disconnect`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "DisconnectPeer attempts to disconnect one peer from another identified by a",
             "given pubKey. In the case that we currently have a pending or active channel",
             "with the target peer, then this action will be not be allowed.",
@@ -12240,10 +12246,9 @@ func Lightning_ListPeers() Method {
     return Method{
         Name: "ListPeers",
         Service: "Lightning",
+        Category: "Peer",
+        ShortDescription: "List all active, currently connected peers",
         Description: []string{
-            "lncli: `listpeers`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "ListPeers returns a verbose listing of all currently active peers.",
         },
         Req: mklnrpc_ListPeersRequest(),
@@ -12255,8 +12260,6 @@ func Lightning_SubscribePeerEvents() Method {
         Name: "SubscribePeerEvents",
         Service: "Lightning",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "SubscribePeerEvents creates a uni-directional stream from the server to",
             "the client in which any events relevant to the state of peers are sent",
             "over. Events include peers going online and offline.",
@@ -12270,9 +12273,6 @@ func Lightning_GetInfo() Method {
         Name: "GetInfo",
         Service: "Lightning",
         Description: []string{
-            "lncli: `getinfo`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "GetInfo returns general information concerning the lightning node including",
             "it's identity pubkey, alias, the chains it is connected to, and information",
             "concerning the number of open+pending channels.",
@@ -12287,8 +12287,6 @@ func Lightning_GetRecoveryInfo() Method {
         Service: "Lightning",
         Description: []string{
             "lncli: `getrecoveryinfo`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "GetRecoveryInfo returns information concerning the recovery mode including",
             "whether it's in a recovery mode, whether the recovery is finished, and the",
             "progress made so far.",
@@ -12394,8 +12392,6 @@ func Lightning_FundingStateStep() Method {
         Name: "FundingStateStep",
         Service: "Lightning",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "FundingStateStep is an advanced funding related call that allows the caller",
             "to either execute some preparatory steps for a funding workflow, or",
             "manually progress a funding workflow. The primary way a funding flow is",
@@ -12414,8 +12410,6 @@ func Lightning_ChannelAcceptor() Method {
         Name: "ChannelAcceptor",
         Service: "Lightning",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "ChannelAcceptor dispatches a bi-directional streaming RPC in which",
             "OpenChannel requests are sent to the client and the client responds with",
             "a boolean that tells LND whether or not to accept the channel. This allows",
@@ -12574,8 +12568,6 @@ func Lightning_SubscribeInvoices() Method {
         Name: "SubscribeInvoices",
         Service: "Lightning",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "SubscribeInvoices returns a uni-directional stream (server -> client) for",
             "notifying the client of newly added/settled invoices. The caller can",
             "optionally specify the add_index and/or the settle_index. If the add_index",
@@ -12730,10 +12722,9 @@ func Lightning_StopDaemon() Method {
     return Method{
         Name: "StopDaemon",
         Service: "Lightning",
+        Category: "Meta",
+        ShortDescription: "Stop and shutdown the daemon",
         Description: []string{
-            "lncli: `stop`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "StopDaemon will send a shutdown request to the interrupt handler, triggering",
             "a graceful shutdown of the daemon.",
         },
@@ -12761,10 +12752,9 @@ func Lightning_DebugLevel() Method {
     return Method{
         Name: "DebugLevel",
         Service: "Lightning",
+        Category: "Meta",
+        ShortDescription: "Set the debug level",
         Description: []string{
-            "lncli: `debuglevel`",
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "DebugLevel allows a caller to programmatically set the logging verbosity of",
             "lnd. The logging can be targeted according to a coarse daemon-wide logging",
             "level, or in a granular fashion to specify the logging for a target",
@@ -12908,9 +12898,9 @@ func Lightning_ReSync() Method {
     return Method{
         Name: "ReSync",
         Service: "Lightning",
+        Category: "Unspent",
+        ShortDescription: "Scan over the chain to find any transactions which may not have been recorded in the wallet's database",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Scan over the chain to find any transactions which may not have been recorded in the wallet's database",
         },
         Req: mklnrpc_ReSyncChainRequest(),
@@ -12921,9 +12911,9 @@ func Lightning_StopReSync() Method {
     return Method{
         Name: "StopReSync",
         Service: "Lightning",
+        Category: "Unspent",
+        ShortDescription: "Stop a re-synchronization job before it's completion",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Stop a re-synchronization job before it's completion",
         },
         Req: mklnrpc_StopReSyncRequest(),
@@ -12934,9 +12924,9 @@ func Lightning_GetWalletSeed() Method {
     return Method{
         Name: "GetWalletSeed",
         Service: "Lightning",
+        Category: "Wallet",
+        ShortDescription: "Get the wallet seed words for this wallet",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Get the wallet seed words for this wallet",
         },
         Req: mklnrpc_GetWalletSeedRequest(),
@@ -12947,9 +12937,9 @@ func Lightning_ChangeSeedPassphrase() Method {
     return Method{
         Name: "ChangeSeedPassphrase",
         Service: "Lightning",
+        Category: "Seed",
+        ShortDescription: "Alter the passphrase which is used to encrypt a wallet seed",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Change seed's passphrase",
         },
         Req: mklnrpc_ChangeSeedPassphraseRequest(),
@@ -12960,9 +12950,9 @@ func Lightning_GetSecret() Method {
     return Method{
         Name: "GetSecret",
         Service: "Lightning",
+        Category: "Wallet",
+        ShortDescription: "Get a secret seed",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Get a secret seed which is generated using the wallet's private key, this can be used as a password for another application",
         },
         Req: mklnrpc_GetSecretRequest(),
@@ -12973,9 +12963,9 @@ func Lightning_ImportPrivKey() Method {
     return Method{
         Name: "ImportPrivKey",
         Service: "Lightning",
+        Category: "Address",
+        ShortDescription: "Imports a WIF-encoded private key to the 'imported' account",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Imports a WIF-encoded private key to the 'imported' account.",
         },
         Req: mklnrpc_ImportPrivKeyRequest(),
@@ -12986,9 +12976,9 @@ func Lightning_DumpPrivKey() Method {
     return Method{
         Name: "DumpPrivKey",
         Service: "Lightning",
+        Category: "Address",
+        ShortDescription: "Returns the private key in WIF encoding that controls some wallet address",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Returns the private key in WIF encoding that controls some wallet address.",
         },
         Req: mklnrpc_DumpPrivKeyRequest(),
@@ -12999,9 +12989,9 @@ func Lightning_ListLockUnspent() Method {
     return Method{
         Name: "ListLockUnspent",
         Service: "Lightning",
+        Category: "Lock",
+        ShortDescription: "Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Returns a JSON array of outpoints marked as locked (with lockunspent) for this wallet session.",
         },
         Req: mklnrpc_ListLockUnspentRequest(),
@@ -13012,9 +13002,9 @@ func Lightning_LockUnspent() Method {
     return Method{
         Name: "LockUnspent",
         Service: "Lightning",
+        Category: "Lock",
+        ShortDescription: "Locks or unlocks an unspent output",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Locks or unlocks an unspent output",
         },
         Req: mklnrpc_LockUnspentRequest(),
@@ -13025,9 +13015,9 @@ func Lightning_CreateTransaction() Method {
     return Method{
         Name: "CreateTransaction",
         Service: "Lightning",
+        Category: "Transaction",
+        ShortDescription: "Create a transaction but do not send it to the chain",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Create a transaction but po not send it to the chain",
         },
         Req: mklnrpc_CreateTransactionRequest(),
@@ -13038,9 +13028,9 @@ func Lightning_GetNewAddress() Method {
     return Method{
         Name: "GetNewAddress",
         Service: "Lightning",
+        Category: "Address",
+        ShortDescription: "Generates a new address",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Generates and returns a new payment address",
         },
         Req: mklnrpc_GetNewAddressRequest(),
@@ -13051,9 +13041,9 @@ func Lightning_GetTransaction() Method {
     return Method{
         Name: "GetTransaction",
         Service: "Lightning",
+        Category: "Transaction",
+        ShortDescription: "Returns a JSON object with details regarding a transaction relevant to this wallet",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Returns a JSON object with details regarding a transaction relevant to this wallet.",
         },
         Req: mklnrpc_GetTransactionRequest(),
@@ -13064,9 +13054,9 @@ func Lightning_SetNetworkStewardVote() Method {
     return Method{
         Name: "SetNetworkStewardVote",
         Service: "Lightning",
+        Category: "Network Steward Vote",
+        ShortDescription: "Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Configure the wallet to vote for a network steward when making payments (note: payments to segwit addresses cannot vote)",
         },
         Req: mklnrpc_SetNetworkStewardVoteRequest(),
@@ -13077,9 +13067,9 @@ func Lightning_GetNetworkStewardVote() Method {
     return Method{
         Name: "GetNetworkStewardVote",
         Service: "Lightning",
+        Category: "Network Steward Vote",
+        ShortDescription: "Find out how the wallet is currently configured to vote in a network steward election",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Find out how the wallet is currently configured to vote in a network steward election",
         },
         Req: mklnrpc_GetNetworkStewardVoteRequest(),
@@ -13090,9 +13080,9 @@ func Lightning_BcastTransaction() Method {
     return Method{
         Name: "BcastTransaction",
         Service: "Lightning",
+        Category: "Neutrino",
+        ShortDescription: "Broadcast a transaction onchain",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
             "Broadcast a transaction",
         },
         Req: mklnrpc_BcastTransactionRequest(),
@@ -13103,10 +13093,10 @@ func Lightning_SendFrom() Method {
     return Method{
         Name: "SendFrom",
         Service: "Lightning",
+        Category: "Transaction",
+        ShortDescription: "Authors, signs, and sends a transaction that outputs some amount to a payment address",
         Description: []string{
-            "$pld.category: ``",
-            "$pld.short_description: ``",
-            "SendFrom uthors, signs, and sends a transaction that outputs some amount to a payment address.",
+            "SendFrom authors, signs, and sends a transaction that outputs some amount to a payment address.",
         },
         Req: mklnrpc_SendFromRequest(),
         Res: mklnrpc_SendFromResponse(),


### PR DESCRIPTION
The following were added/changed/fixed:

. move command category + short description to proto files in such a way that all help info is generated from proto docs;
. change in command help to use info from the proto data;
. change in internal data structures to have a deterministic behaviour in command list for master help (pld & pldctl);
