### PR TITLE
added start and end timestamp to trnsactions/query

### DIFF
--- a/lnd/lnrpc/walletrpc/walletkit_server.go
+++ b/lnd/lnrpc/walletrpc/walletkit_server.go
@@ -716,7 +716,7 @@ func (w *WalletKit) ListSweeps0(ctx context.Context,
 	// can match our list of sweeps against the list of transactions that
 	// the wallet is still tracking.
 	transactions, err := w.cfg.Wallet.ListTransactionDetails(
-		0, btcwallet.UnconfirmedHeight, 0, 0, 0, false,
+		0, btcwallet.UnconfirmedHeight, 0, 0, 0, false,0,0,
 	)
 	if err != nil {
 		return nil, err

--- a/lnd/lntest/mock/walletcontroller.go
+++ b/lnd/lntest/mock/walletcontroller.go
@@ -121,7 +121,7 @@ func (w *WalletController) ListUnspentWitness(minconfirms,
 
 // ListTransactionDetails currently returns dummy values.
 func (w *WalletController) ListTransactionDetails(_,
-	_, _, _, _ int32, _ bool) ([]*lnwallet.TransactionDetail, er.R) {
+	_, _, _, _ int32, _ bool, _, _ int64) ([]*lnwallet.TransactionDetail, er.R) {
 
 	return nil, nil
 }

--- a/lnd/lnwallet/btcwallet/btcwallet.go
+++ b/lnd/lnwallet/btcwallet/btcwallet.go
@@ -649,17 +649,17 @@ func unminedTransactionsToDetail(
 //
 // This is a part of the WalletController interface.
 func (b *BtcWallet) ListTransactionDetails(startHeight,
-	endHeight, skip, limit, coinbase int32, reversed bool) ([]*lnwallet.TransactionDetail, er.R) {
+	endHeight, skip, limit, coinbase int32, reversed bool, startTimestamp int64, endTimestamp int64) ([]*lnwallet.TransactionDetail, er.R) {
 
 	// Grab the best block the wallet knows of, we'll use this to calculate
 	// # of confirmations shortly below.
 	bestBlock := b.wallet.Manager.SyncedTo()
 	currentHeight := bestBlock.Height
-
+ 
 	// We'll attempt to find all transactions from start to end height.
 	start := base.NewBlockIdentifierFromHeight(startHeight)
 	stop := base.NewBlockIdentifierFromHeight(endHeight)
-	txns, err := b.wallet.GetTransactions(start, stop, limit, skip, coinbase, reversed, nil)
+	txns, err := b.wallet.GetTransactions(start, stop, limit, skip, coinbase, reversed, startTimestamp, endTimestamp, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/lnd/lnwallet/interface.go
+++ b/lnd/lnwallet/interface.go
@@ -218,7 +218,7 @@ type WalletController interface {
 	// the tip of the chain until the start height (inclusive) and
 	// unconfirmed transactions.
 	ListTransactionDetails(startHeight,
-		endHeight, skip, limit, coinbase int32, reversed bool) ([]*TransactionDetail, er.R)
+		endHeight, skip, limit, coinbase int32, reversed bool, startTimestamp, endTimestamp int64) ([]*TransactionDetail, er.R)
 
 	// LockOutpoint marks an outpoint as locked meaning it will no longer
 	// be deemed as eligible for coin selection. Locking outputs are

--- a/lnd/rpcserver.go
+++ b/lnd/rpcserver.go
@@ -4233,8 +4233,16 @@ func (r *LightningRPCServer) GetTransactions(ctx context.Context,
 	if req.Coinbase != 0 {
 		coinbase = req.Coinbase
 	}
+	var startTimestamp int64 = 0
+	if req.StartTimestamp != 0 {
+		startTimestamp = req.StartTimestamp
+	}
+	var endTimestamp int64 = 0
+	if req.EndTimestamp != 0 {
+		endTimestamp = req.EndTimestamp
+	}
 
-	transactions, err := r.server.cc.Wallet.ListTransactionDetails(req.StartHeight, endHeight, skip, limit, coinbase, req.Reversed)
+	transactions, err := r.server.cc.Wallet.ListTransactionDetails(req.StartHeight, endHeight, skip, limit, coinbase, req.Reversed, startTimestamp, endTimestamp)
 	if err != nil {
 		return nil, er.Native(err)
 	}

--- a/pktwallet/wallet/wallet.go
+++ b/pktwallet/wallet/wallet.go
@@ -1642,6 +1642,7 @@ func (w *Wallet) GetTransactions(
 	startBlock, endBlock *BlockIdentifier,
 	limit, skip, //0 means no limit imposed
 	coinbase int32, reversed bool,
+	startTimestamp, endTimestamp int64,
 	cancel <-chan struct{},
 ) (*GetTransactionsResult, er.R) {
 	var start, end int32 = 0, -1
@@ -1681,7 +1682,7 @@ func (w *Wallet) GetTransactions(
 			}
 		}
 	}
-	log.Infof("Default skip: %d, limit:%d, coinbase:%d\n", skip, limit, coinbase)
+
 	var res GetTransactionsResult
 	var totalTxns = 0
 	var skippedtxns int32 = 0
@@ -1707,6 +1708,14 @@ func (w *Wallet) GetTransactions(
 					} else if coinbase == coinbaseOnly {
 						txs = txs[:1]
 					}
+				}
+				//Checking for time
+				if (startTimestamp > 0) && (endTimestamp > 0) {
+					var blockTime = details[0].Block.Time.Unix()
+					if !((blockTime > startTimestamp) && (blockTime < endTimestamp)) {
+						//Block is not within the requested time range, skip it
+						txs = txs[:0]
+					} 
 				}
 				//Skipping transactions
 				if (skippedtxns + int32(len(txs))) < skip {

--- a/proto/rpc_pb/rpc.proto
+++ b/proto/rpc_pb/rpc.proto
@@ -817,6 +817,14 @@ message GetTransactionsRequest {
     of the returned payments is always oldest first (ascending index order).
     */
     bool reversed = 6;
+    /*
+    Start and end timestamp in seconds for date range for which to list transactions.
+    If date range is not provided, the query will follow start and end height parameters.
+    Both start and end timestamps must be provided.
+    start_height and end_height have precedence over start_time and end_time.
+    */
+    int64 start_timestamp = 7;
+    int64 end_timestamp = 8;
 }
 
 message TransactionDetails {


### PR DESCRIPTION
Added startTimestamp and endTimestamp to wallet/transaction/query call.
when both are != 0 transactions that are not with in the time range will be dropped from the response.